### PR TITLE
[X-Address] Consider X-Addresses as valid address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,14 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@types/base-x": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/base-x/-/base-x-3.0.0.tgz",
+      "integrity": "sha512-vnqSlpsv9uFX5/z8GyKWAfWHhLGJDBkrgRRsnxlsX23DHOlNyqP/eHQiv4TwnYcZULzQIxaWA/xRWU9Dyy4qzw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/bytebuffer": {
       "version": "5.0.40",
       "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
@@ -956,9 +964,12 @@
       }
     },
     "base-x": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
-      "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+      "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "base64-js": {
       "version": "1.3.1",
@@ -6624,12 +6635,13 @@
       }
     },
     "ripple-address-codec": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-2.0.1.tgz",
-      "integrity": "sha1-7dvjp5YNLgLFwcdPuan6DS37ZXE=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-4.0.0.tgz",
+      "integrity": "sha512-PsKl9aytg6fZG2F4RtfPT0c1gj42suAQY9VvJVGz+DfQTdXQaTT9V/StVhaJ6jhVpl7oCd981BB9p2Kq+Kyrng==",
       "requires": {
-        "hash.js": "^1.0.3",
-        "x-address-codec": "^0.7.0"
+        "@types/base-x": "^3.0.0",
+        "base-x": "3.0.4",
+        "create-hash": "^1.1.2"
       }
     },
     "ripple-binary-codec": {
@@ -6695,6 +6707,17 @@
         "elliptic": "^6.4.0",
         "hash.js": "^1.0.3",
         "ripple-address-codec": "^2.0.1"
+      },
+      "dependencies": {
+        "ripple-address-codec": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-2.0.1.tgz",
+          "integrity": "sha1-7dvjp5YNLgLFwcdPuan6DS37ZXE=",
+          "requires": {
+            "hash.js": "^1.0.3",
+            "x-address-codec": "^0.7.0"
+          }
+        }
       }
     },
     "run-async": {
@@ -8061,6 +8084,13 @@
       "integrity": "sha1-Ki97sAJ4UgvRNzOnlZoFRD1oAuA=",
       "requires": {
         "base-x": "^1.0.1"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
+          "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
+        }
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grpc": "1.23.3",
     "grpc_tools_node_protoc_ts": "2.5.4",
     "is-hex": "^1.1.3",
-    "ripple-address-codec": "^2.0.1",
+    "ripple-address-codec": "4.0.0",
     "ripple-binary-codec": "0.2.4",
     "ripple-keypairs": "^0.11.0",
     "typescript": "3.5.3"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,20 +5,23 @@ var addressCodec = require("ripple-address-codec");
 class Utils {
   /**
    * Validate that the given string is a valid address on the XRP Ledger.
-   * 
+   *
    * This function returns true for both x-addresses and classic addresses.
    * @see https://xrpaddress.info/
-   * 
+   *
    * @param address An address to check.
    * @returns True if the address is valid, otherwise false.
    */
   public static isValidAddress(address: string): boolean {
-    return addressCodec.isValidClassicAddress(address) || addressCodec.isValidXAddress(address);
+    return (
+      addressCodec.isValidClassicAddress(address) ||
+      addressCodec.isValidXAddress(address)
+    );
   }
 
   /**
    * Convert the given byte array to a hexadecimal string.
-   * 
+   *
    * @param bytes An array of bytes
    * @returns An encoded hexadecimal string.
    */
@@ -28,7 +31,7 @@ class Utils {
 
   /**
    * Convert the given hexadecimal string to a byte array.
-   * 
+   *
    * @param hex A hexadecimal string.
    * @returns A decoded byte array.
    */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ class Utils {
   /**
    * Validate that the given string is a valid address on the XRP Ledger.
    *
-   * This function returns true for both x-addresses and classic addresses.
+   * This function returns true for both X-addresses and classic addresses.
    * @see https://xrpaddress.info/
    *
    * @param address An address to check.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,14 +3,35 @@
 var addressCodec = require("ripple-address-codec");
 
 class Utils {
+  /**
+   * Validate that the given string is a valid address on the XRP Ledger.
+   * 
+   * This function returns true for both x-addresses and classic addresses.
+   * @see https://xrpaddress.info/
+   * 
+   * @param address An address to check.
+   * @returns True if the address is valid, otherwise false.
+   */
   public static isValidAddress(address: string): boolean {
-    return addressCodec.isValidAddress(address);
+    return addressCodec.isValidClassicAddress(address) || addressCodec.isValidXAddress(address);
   }
 
+  /**
+   * Convert the given byte array to a hexadecimal string.
+   * 
+   * @param bytes An array of bytes
+   * @returns An encoded hexadecimal string.
+   */
   public static toHex(bytes: Uint8Array): string {
     return Buffer.from(bytes).toString("hex");
   }
 
+  /**
+   * Convert the given hexadecimal string to a byte array.
+   * 
+   * @param hex A hexadecimal string.
+   * @returns A decoded byte array.
+   */
   public static toBytes(hex: string): Uint8Array {
     return Uint8Array.from(Buffer.from(hex, "hex"));
   }

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -14,8 +14,8 @@ describe("utils", function(): void {
     assert.isTrue(validAddress);
   });
 
-  it("isValidAddress() - Valid X Address", function(): void {
-    // GIVEN a valid x-address.
+  it("isValidAddress() - Valid X-Address", function(): void {
+    // GIVEN a valid X-address.
     const address = "XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi";
 
     // WHEN the address is validated.
@@ -47,8 +47,8 @@ describe("utils", function(): void {
     assert.isFalse(validAddress);
   });
 
-  it("isValidAddress() - Invalid X Address Checksum", function(): void {
-    // GIVEN a classic address which fails checksumming in base58 encoding.
+  it("isValidAddress() - Invalid X-Address Checksum", function(): void {
+    // GIVEN an X-address which fails checksumming in base58 encoding.
     const address = "XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHI";
 
     // WHEN the address is validated.

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -3,9 +3,20 @@ import { assert } from "chai";
 import "mocha";
 
 describe("utils", function(): void {
-  it("isValidAddress() - Valid Address", function(): void {
-    // GIVEN a valid address.
+  it("isValidAddress() - Valid Classic Address", function(): void {
+    // GIVEN a valid classic address.
     const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+
+    // WHEN the address is validated.
+    const validAddress = Utils.isValidAddress(address);
+
+    // THEN the address is deemed valid.
+    assert.isTrue(validAddress);
+  });
+
+  it("isValidAddress() - Valid X Address", function(): void {
+    // GIVEN a valid x-address.
+    const address = "XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi";
 
     // WHEN the address is validated.
     const validAddress = Utils.isValidAddress(address);
@@ -25,9 +36,20 @@ describe("utils", function(): void {
     assert.isFalse(validAddress);
   });
 
-  it("isValidAddress() - Invalid Checksum", function(): void {
-    // GIVEN a base58check address which fails checksumming.
+  it("isValidAddress() - Invalid Classic Address Checksum", function(): void {
+    // GIVEN a classic address which fails checksumming in base58 encoding.
     const address = "rU6K7V3Po4sBBBBBaU29sesqs2qTQJWDw1";
+
+    // WHEN the address is validated.
+    const validAddress = Utils.isValidAddress(address);
+
+    // THEN the address is deemed invalid.
+    assert.isFalse(validAddress);
+  });
+
+  it("isValidAddress() - Invalid X Address Checksum", function(): void {
+    // GIVEN a classic address which fails checksumming in base58 encoding.
+    const address = "XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHI";
 
     // WHEN the address is validated.
     const validAddress = Utils.isValidAddress(address);


### PR DESCRIPTION
Update the implementation of `Utils` class to work with x-addresses. The new implementation doesn't distinguish between x-address and classic addresses as I don't see an obvious use case for why a Xpring SDK user want's this functionality.

Changes:
- Updates the underlying `ripple-address-codec` dependency to 4.0.0, which has x-address support. 
- Updates the implementation of `Utils.isValidAddress` for breaking changes in dependency update and to validate x-addresses
- [Cleanup] Add missing documentation in other utils

New APIs:
N/A

Breaking Changes:
N/A

See Also: 
X-Address Format: https://xrpaddress.info/