### PR TITLE
[X-Address] Add Encoding and Decoding of X-Addresses

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,25 @@ class Utils {
   }
 
   /**
+   * Encode the given classic address and tag into an x-address.
+   * 
+   * @see https://xrpaddress.info/
+   * 
+   * @param classicAddress A classic address to encode.
+   * @param tag An optional tag to encode.
+   * @returns A new x-address if inputs were valid, otherwise undefined.
+   */
+  public static encodeXAddress(classicAddress: string, tag: number|undefined): string|undefined {
+    if (!addressCodec.isValidClassicAddress(classicAddress)) {
+      return undefined;
+    }
+
+    // Xpring Common JS's API takes a string|undefined while the underlying address library wants string|false.
+    const shimTagParameter = tag != undefined ? tag : false;
+    return addressCodec.classicAddressToXAddress(classicAddress, shimTagParameter)
+  }
+
+  /**
    * Convert the given byte array to a hexadecimal string.
    *
    * @param bytes An array of bytes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ export interface ClassicAddress {
   address: string;
 
   /** An optional tag. */
-  tag: number | undefined;
+  tag?: number;
 }
 
 class Utils {
@@ -48,7 +48,7 @@ class Utils {
     }
 
     // Xpring Common JS's API takes a string|undefined while the underlying address library wants string|false.
-    const shimTagParameter = tag != undefined ? tag : false;
+    const shimTagParameter = tag !== undefined ? tag : false;
     return addressCodec.classicAddressToXAddress(
       classicAddress,
       shimTagParameter
@@ -71,7 +71,7 @@ class Utils {
     let shimClassicAddress = addressCodec.xAddressToClassicAddress(xAddress);
     return {
       address: shimClassicAddress.classicAddress,
-      tag: shimClassicAddress.tag != false ? shimClassicAddress.tag : undefined
+      tag: shimClassicAddress.tag !== false ? shimClassicAddress.tag : undefined
     };
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,17 @@
 
 var addressCodec = require("ripple-address-codec");
 
+/**
+ * A simple property bag which contains components of a classic address. Components contained in this object are neither sanitized or validated.
+ */
+export interface ClassicAddress {
+  /** A classic address. */
+  address: string;
+
+  /** An optional tag. */
+  tag: number | undefined;
+}
+
 class Utils {
   /**
    * Validate that the given string is a valid address on the XRP Ledger.
@@ -21,21 +32,47 @@ class Utils {
 
   /**
    * Encode the given classic address and tag into an x-address.
-   * 
+   *
    * @see https://xrpaddress.info/
-   * 
+   *
    * @param classicAddress A classic address to encode.
    * @param tag An optional tag to encode.
    * @returns A new x-address if inputs were valid, otherwise undefined.
    */
-  public static encodeXAddress(classicAddress: string, tag: number|undefined): string|undefined {
+  public static encodeXAddress(
+    classicAddress: string,
+    tag: number | undefined
+  ): string | undefined {
     if (!addressCodec.isValidClassicAddress(classicAddress)) {
       return undefined;
     }
 
     // Xpring Common JS's API takes a string|undefined while the underlying address library wants string|false.
     const shimTagParameter = tag != undefined ? tag : false;
-    return addressCodec.classicAddressToXAddress(classicAddress, shimTagParameter)
+    return addressCodec.classicAddressToXAddress(
+      classicAddress,
+      shimTagParameter
+    );
+  }
+
+  /**
+   * Decode a `ClassicAddress` from a given x-address.
+   *
+   * @see https://xrpaddress.info/
+   *
+   * @param xAddress The xAddress to decode.
+   * @returns A `ClassicAddress`
+   */
+  public static decodeXAddress(xAddress: string): ClassicAddress | undefined {
+    if (!addressCodec.isValidXAddress(xAddress)) {
+      return undefined;
+    }
+
+    let shimClassicAddress = addressCodec.xAddressToClassicAddress(xAddress);
+    return {
+      address: shimClassicAddress.classicAddress,
+      tag: shimClassicAddress.tag != false ? shimClassicAddress.tag : undefined
+    };
   }
 
   /**

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -91,4 +91,38 @@ describe("utils", function(): void {
     // THEN the address is deemed invalid.
     assert.isFalse(validAddress);
   });
+
+  it("encodeXAddress() - Address and Tag", function(): void {
+    // GIVEN a valid classic address and a tag. 
+    const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+    const tag = 12345
+
+    // WHEN they are encoded to an x-address.
+    const xAddress = Utils.encodeXAddress(address, tag);
+
+    // THEN the result is as expected.
+    assert.strictEqual(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT");
+  });
+
+  it("encodeXAddress() - Address Only", function(): void {
+    // GIVEN a valid classic address.
+    const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+
+    // WHEN it is encoded to an x-address.
+    const xAddress = Utils.encodeXAddress(address, undefined);
+
+    // THEN the result is as expected.
+    assert.strictEqual(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH");
+  });
+
+  it("encodeXAddress() - Invalid Address", function(): void {
+    // GIVEN an invalid address.
+    const address = "xrp";
+
+    // WHEN it is encoded to an x-address.
+    const xAddress = Utils.encodeXAddress(address, undefined);
+
+    // THEN the result is undefined.
+    assert.isUndefined(xAddress);
+  });
 });

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -2,6 +2,9 @@ import Utils from "../src/utils";
 import { assert } from "chai";
 import "mocha";
 
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 describe("utils", function(): void {
   it("isValidAddress() - Valid Classic Address", function(): void {
     // GIVEN a valid classic address.
@@ -93,15 +96,18 @@ describe("utils", function(): void {
   });
 
   it("encodeXAddress() - Address and Tag", function(): void {
-    // GIVEN a valid classic address and a tag. 
+    // GIVEN a valid classic address and a tag.
     const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
-    const tag = 12345
+    const tag = 12345;
 
     // WHEN they are encoded to an x-address.
     const xAddress = Utils.encodeXAddress(address, tag);
 
     // THEN the result is as expected.
-    assert.strictEqual(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT");
+    assert.strictEqual(
+      xAddress,
+      "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"
+    );
   });
 
   it("encodeXAddress() - Address Only", function(): void {
@@ -112,7 +118,10 @@ describe("utils", function(): void {
     const xAddress = Utils.encodeXAddress(address, undefined);
 
     // THEN the result is as expected.
-    assert.strictEqual(xAddress, "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH");
+    assert.strictEqual(
+      xAddress,
+      "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH"
+    );
   });
 
   it("encodeXAddress() - Invalid Address", function(): void {
@@ -123,6 +132,41 @@ describe("utils", function(): void {
     const xAddress = Utils.encodeXAddress(address, undefined);
 
     // THEN the result is undefined.
+    assert.isUndefined(xAddress);
+  });
+
+  it("decodeXAddress() - Valid Address with Tag", function(): void {
+    // GIVEN an x-address that encodes an address and a tag.
+    const address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT";
+
+    // WHEN it is decoded to an classic address
+    const xAddress = Utils.decodeXAddress(address);
+
+    // Then the decoded address and tag as are expected.
+    assert.strictEqual(xAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.strictEqual(xAddress!.tag, 12345);
+  });
+
+  it("decodeXAddress() - Valid Address without Tag", function(): void {
+    // GIVEN an x-address that encodes an address and no tag.
+    const address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH";
+
+    // WHEN it is decoded to an classic address
+    const xAddress = Utils.decodeXAddress(address);
+
+    // Then the decoded address and tag as are expected.
+    assert.strictEqual(xAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.isUndefined(xAddress!.tag);
+  });
+
+  it("decodeXAddress() - Invalid Address", function(): void {
+    // GIVEN an invalid address
+    const address = "xrp";
+
+    // WHEN it is decoded to an classic address
+    const xAddress = Utils.decodeXAddress(address);
+
+    // Then the decoded address is undefined.
     assert.isUndefined(xAddress);
   });
 });


### PR DESCRIPTION
Add methods on `Utils` class to encode and decode x-addresses. 

Note minor shims are required to work with the underlying library. The underlying library prefers `string|false` while Xpring Common JS prefers `string|undefined`. `undefined` is preferred because it works well with strongly typed languages (ie. `String` in java is `String` of `null`) and optional monads (i.e. `String` in swift is always `String` and `String?` is `String` or `nil`).

Changes:
- Add new APIs to `Utils` class
- Add new `ClassicAddress` interface representing the property bag of objects returned from x-address decoding.

New APIs:
- `Utils.encodeXAddress(address: string, tag: number|undefined): string|undefined`
- `Utils.decodeXAddres(xAddress: string): ClassicAddress|undefined`

Breaking Changes:
N/A

See Also: 
X-Address Format: https://xrpaddress.info/