### PR TITLE
Implement X-Address functionality in Serializer.

### DIFF
--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -83,7 +83,7 @@ class Serializer {
       delete json.DestinationTag;
     } else {
       json.Destination = decodedXAddress.address;
-      if (decodedXAddress.tag) {
+      if (decodedXAddress.tag !== undefined) {
         json.DestinationTag = decodedXAddress.tag;
       }
     }

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -11,7 +11,7 @@ import Utils from "./utils";
 interface PaymentJSON {
   Amount: object | string;
   Destination: string;
-  DestinationTag?: number | undefined;
+  DestinationTag?: number;
   TransactionType: string;
 }
 

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -79,7 +79,7 @@ class Serializer {
 
     // If an x-address was able to be decoded, add the components to the json.
     const decodedXAddress = Utils.decodeXAddress(payment.getDestination());
-    if (decodedXAddress === undefined) {
+    if (!decodedXAddress) {
       json.Destination = payment.getDestination();
       delete json.DestinationTag;
     } else {

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -73,7 +73,6 @@ class Serializer {
     const json: PaymentJSON = {
       Amount: {},
       Destination: "",
-      DestinationTag: 0,
       TransactionType: "Payment"
     };
 
@@ -84,7 +83,9 @@ class Serializer {
       delete json.DestinationTag;
     } else {
       json.Destination = decodedXAddress.address;
-      json.DestinationTag = decodedXAddress.tag;
+      if (decodedXAddress.tag) {
+        json.DestinationTag = decodedXAddress.tag;
+      }
     }
 
     const amountCase = payment.getAmountCase();

--- a/test/serializer-test.ts
+++ b/test/serializer-test.ts
@@ -40,7 +40,7 @@ describe("serializer", function(): void {
     // THEN the result is as expected.
     const expectedJSON = {
       Account: account,
-      Amount: value + "",
+      Amount: value.toString(),
       Destination: destination,
       Fee: fee,
       Sequence: sequence,
@@ -82,7 +82,7 @@ describe("serializer", function(): void {
     // THEN the result is as expected.
     const expectedJSON = {
       Account: account,
-      Amount: value + "",
+      Amount: value.toString(),
       Destination: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1",
       DestinationTag: 12345,
       Fee: fee,
@@ -125,7 +125,7 @@ describe("serializer", function(): void {
     // THEN the result is as expected.
     const expectedJSON = {
       Account: account,
-      Amount: value + "",
+      Amount: value.toString(),
       Destination: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1",
       DestinationTag: undefined,
       Fee: fee,

--- a/test/serializer-test.ts
+++ b/test/serializer-test.ts
@@ -127,7 +127,6 @@ describe("serializer", function(): void {
       Account: account,
       Amount: value.toString(),
       Destination: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1",
-      DestinationTag: undefined,
       Fee: fee,
       Sequence: sequence,
       TransactionType: "Payment",

--- a/test/serializer-test.ts
+++ b/test/serializer-test.ts
@@ -9,7 +9,7 @@ import "mocha";
 
 describe("serializer", function(): void {
   it("serializes a payment in XRP", function(): void {
-    // GIVEN a transaction which represents a payment denominated in Fiat.
+    // GIVEN a transaction which represents a payment denominated in XRP.
     const value = "1000";
     const destination = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh";
     const fee = "10";
@@ -42,6 +42,92 @@ describe("serializer", function(): void {
       Account: account,
       Amount: value + "",
       Destination: destination,
+      Fee: fee,
+      Sequence: sequence,
+      TransactionType: "Payment",
+      SigningPubKey: publicKey
+    };
+    assert.deepEqual(serialized, expectedJSON);
+  });
+
+  it("serializes a payment to an X-address with a tag in XRP", function(): void {
+    // GIVEN a transaction which represents a payment to a destination and tag, denominated in XRP.
+    const value = "1000";
+    const destination = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT";
+    const fee = "10";
+    const sequence = 1;
+    const account = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ";
+    const publicKey = "testPublicKey";
+
+    const paymentAmount = new XRPAmount();
+    paymentAmount.setDrops(value);
+
+    const payment = new Payment();
+    payment.setDestination(destination);
+    payment.setXrpAmount(paymentAmount);
+
+    const transactionFee = new XRPAmount();
+    transactionFee.setDrops(fee);
+
+    const transaction = new Transaction();
+    transaction.setAccount(account);
+    transaction.setFee(transactionFee);
+    transaction.setSequence(sequence);
+    transaction.setPayment(payment);
+    transaction.setSigningPublicKeyHex(publicKey);
+
+    // WHEN the transaction is serialized to JSON.
+    const serialized = Serializer.transactionToJSON(transaction);
+
+    // THEN the result is as expected.
+    const expectedJSON = {
+      Account: account,
+      Amount: value + "",
+      Destination: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1",
+      DestinationTag: 12345,
+      Fee: fee,
+      Sequence: sequence,
+      TransactionType: "Payment",
+      SigningPubKey: publicKey
+    };
+    assert.deepEqual(serialized, expectedJSON);
+  });
+
+  it("serializes a payment to an X-address without a tag in XRP", function(): void {
+    // GIVEN a transaction which represents a payment to a destination without a tag, denominated in XRP.
+    const value = "1000";
+    const destination = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH";
+    const fee = "10";
+    const sequence = 1;
+    const account = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ";
+    const publicKey = "testPublicKey";
+
+    const paymentAmount = new XRPAmount();
+    paymentAmount.setDrops(value);
+
+    const payment = new Payment();
+    payment.setDestination(destination);
+    payment.setXrpAmount(paymentAmount);
+
+    const transactionFee = new XRPAmount();
+    transactionFee.setDrops(fee);
+
+    const transaction = new Transaction();
+    transaction.setAccount(account);
+    transaction.setFee(transactionFee);
+    transaction.setSequence(sequence);
+    transaction.setPayment(payment);
+    transaction.setSigningPublicKeyHex(publicKey);
+
+    // WHEN the transaction is serialized to JSON.
+    const serialized = Serializer.transactionToJSON(transaction);
+
+    // THEN the result is as expected.
+    const expectedJSON = {
+      Account: account,
+      Amount: value + "",
+      Destination: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1",
+      DestinationTag: undefined,
       Fee: fee,
       Sequence: sequence,
       TransactionType: "Payment",


### PR DESCRIPTION
Fields ii a Payment protocol buffer could either be a classic address or an X-address.  This PR decodes and correctly handles the X-Address case. 

Note that for simplicity, I've chosen to not implement a `DestinationTag` in the underlying protocol buffers. Instead, Payments which want to use a `DestinationTag` will have to encode their own X-addresses. In practice, the end user's library (Xpring-JS, XpringKit, etc) will do this for them and they will be none the wiser. 

Added unit tests as well. 