### PR TITLE
Add Utility Function for Transaction Hashing 

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 "use strict";
 
-import { createHash } from 'crypto'
+import { createHash } from "crypto";
 
 const addressCodec = require("ripple-address-codec");
 const isHex = require("is-hex");
@@ -85,7 +85,9 @@ class Utils {
    * @returns An encoded hexadecimal string.
    */
   public static toHex(bytes: Uint8Array): string {
-    return Buffer.from(bytes).toString("hex").toUpperCase();
+    return Buffer.from(bytes)
+      .toString("hex")
+      .toUpperCase();
   }
 
   /**
@@ -100,16 +102,20 @@ class Utils {
 
   /**
    * Convert the given transaction blob to a transaction hash.
-   * 
+   *
    * @param transactionBlobHex A hexadecimal encoded transaction blob.
    * @returns A hex encoded hash if the input was valid, otherwise undefined.
    */
-  public static transactionBlobToTransactionHash(transactionBlobHex: string): string|undefined {
+  public static transactionBlobToTransactionHash(
+    transactionBlobHex: string
+  ): string | undefined {
     if (!isHex(transactionBlobHex)) {
-      return undefined
+      return undefined;
     }
 
-    const prefixedTransactionBlob = this.toBytes("54584E00" + transactionBlobHex);
+    const prefixedTransactionBlob = this.toBytes(
+      "54584E00" + transactionBlobHex
+    );
     const hash = this.sha512Half(prefixedTransactionBlob);
     return this.toHex(hash);
   }
@@ -122,10 +128,15 @@ class Utils {
    */
   private static sha512Half(bytes: Uint8Array): Uint8Array {
     const sha512 = createHash("sha512");
-    const hashHex = sha512.update(bytes).digest('hex').toUpperCase();
+    const hashHex = sha512
+      .update(bytes)
+      .digest("hex")
+      .toUpperCase();
     const hash = this.toBytes(hashHex);
 
+    /* eslint-disable @typescript-eslint/no-magic-numbers */
     return hash.slice(0, hash.length / 2);
+    /* eslint-enable @typescript-eslint/no-magic-numbers */
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,13 @@ const addressCodec = require("ripple-address-codec");
 const isHex = require("is-hex");
 
 /**
+ * A prefex applied when hashing a signed transaction blob.
+ *
+ * @see https://xrpl.org/basic-data-types.html#hashes
+ */
+const signedTransactionPrefixHex = "54584E00";
+
+/**
  * A simple property bag which contains components of a classic address. Components contained in this object are neither sanitized or validated.
  */
 export interface ClassicAddress {
@@ -114,7 +121,7 @@ class Utils {
     }
 
     const prefixedTransactionBlob = this.toBytes(
-      "54584E00" + transactionBlobHex
+      signedTransactionPrefixHex + transactionBlobHex
     );
     const hash = this.sha512Half(prefixedTransactionBlob);
     return this.toHex(hash);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,7 +135,7 @@ class Utils {
     const hash = this.toBytes(hashHex);
 
     /* eslint-disable @typescript-eslint/no-magic-numbers */
-    return hash.slice(0, hash.length / 2);
+    return hash.slice(0, 32);
     /* eslint-enable @typescript-eslint/no-magic-numbers */
   }
 }

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -172,24 +172,31 @@ describe("utils", function(): void {
 
   it("transactionBlobHex() - Valid transaction blob", function(): void {
     // GIVEN a transaction blob.
-    const transactionBlobHex = "120000240000000561400000000000000168400000000000000C73210261BBB9D242440BA38375DAD79B146E559A9DFB99055F7077DA63AE0D643CA0E174473045022100C8BB1CE19DFB1E57CDD60947C5D7F1ACD10851B0F066C28DBAA3592475BC3808022056EEB85CC8CD41F1F1CF635C244943AD43E3CF0CE1E3B7359354AC8A62CF3F488114F8942487EDB0E4FD86190BF8DCB3AF36F608839D83141D10E382F805CD7033CC4582D2458922F0D0ACA6"
+    const transactionBlobHex =
+      "120000240000000561400000000000000168400000000000000C73210261BBB9D242440BA38375DAD79B146E559A9DFB99055F7077DA63AE0D643CA0E174473045022100C8BB1CE19DFB1E57CDD60947C5D7F1ACD10851B0F066C28DBAA3592475BC3808022056EEB85CC8CD41F1F1CF635C244943AD43E3CF0CE1E3B7359354AC8A62CF3F488114F8942487EDB0E4FD86190BF8DCB3AF36F608839D83141D10E382F805CD7033CC4582D2458922F0D0ACA6";
 
-    // WHEN the transaction blob is converted to a hash. 
-    let transactionHash = Utils.transactionBlobToTransactionHash(transactionBlobHex);
+    // WHEN the transaction blob is converted to a hash.
+    let transactionHash = Utils.transactionBlobToTransactionHash(
+      transactionBlobHex
+    );
 
     // THEN the transaction blob is as expected.
-    assert.strictEqual(transactionHash, "7B9F6E019C2A79857427B4EF968D77D683AC84F5A880830955D7BDF47F120667");
-  })
-
+    assert.strictEqual(
+      transactionHash,
+      "7B9F6E019C2A79857427B4EF968D77D683AC84F5A880830955D7BDF47F120667"
+    );
+  });
 
   it("transactionBlobHex() - Invalid transaction blob", function(): void {
     // GIVEN an invalid transaction blob.
-    const transactionBlobHex = "xrp"
+    const transactionBlobHex = "xrp";
 
-    // WHEN the transaction blob is converted to a hash. 
-    let transactionHash = Utils.transactionBlobToTransactionHash(transactionBlobHex);
+    // WHEN the transaction blob is converted to a hash.
+    let transactionHash = Utils.transactionBlobToTransactionHash(
+      transactionBlobHex
+    );
 
     // THEN the hash is undefined.
     assert.isUndefined(transactionHash);
-  })
+  });
 });

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -169,4 +169,27 @@ describe("utils", function(): void {
     // Then the decoded address is undefined.
     assert.isUndefined(xAddress);
   });
+
+  it("transactionBlobHex() - Valid transaction blob", function(): void {
+    // GIVEN a transaction blob.
+    const transactionBlobHex = "120000240000000561400000000000000168400000000000000C73210261BBB9D242440BA38375DAD79B146E559A9DFB99055F7077DA63AE0D643CA0E174473045022100C8BB1CE19DFB1E57CDD60947C5D7F1ACD10851B0F066C28DBAA3592475BC3808022056EEB85CC8CD41F1F1CF635C244943AD43E3CF0CE1E3B7359354AC8A62CF3F488114F8942487EDB0E4FD86190BF8DCB3AF36F608839D83141D10E382F805CD7033CC4582D2458922F0D0ACA6"
+
+    // WHEN the transaction blob is converted to a hash. 
+    let transactionHash = Utils.transactionBlobToTransactionHash(transactionBlobHex);
+
+    // THEN the transaction blob is as expected.
+    assert.strictEqual(transactionHash, "7B9F6E019C2A79857427B4EF968D77D683AC84F5A880830955D7BDF47F120667");
+  })
+
+
+  it("transactionBlobHex() - Invalid transaction blob", function(): void {
+    // GIVEN an invalid transaction blob.
+    const transactionBlobHex = "xrp"
+
+    // WHEN the transaction blob is converted to a hash. 
+    let transactionHash = Utils.transactionBlobToTransactionHash(transactionBlobHex);
+
+    // THEN the hash is undefined.
+    assert.isUndefined(transactionHash);
+  })
 });


### PR DESCRIPTION
The gRPC API doesn't pass back the transaction hash when submitting a transaction. Instead, it returns a hex encoded blob. We need a utility to convert that to a hex, which is what our users will really want to interact with. 

Add a utility to do this. Add unit tests. 

Note: I realize that `Utils` is fast becoming a dumping ground for all sorts of things. I think that this is still small enough that it doesn't justify splitting out a `Hashing` class or the like, but happy to hear reviewer's throughts. 