### PR TITLE
Merge latest protocol buffer updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "1.1.5",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ripple-keypairs": "^0.11.0"
   },
   "scripts": {
+    "build": "tsc -d",
     "clean": "rm -rf ./generated ./dist ./build",
     "pretest": "./scripts/regenerate_protos.sh && tsc",
     "lint": "eslint **/*.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,20 +2,16 @@ export { AccountInfo } from "../generated/account_info_pb";
 export { Currency } from "../generated/currency_pb";
 export { Fee } from "../generated/fee_pb";
 export { FiatAmount } from "../generated/fiat_amount_pb";
-export {
-  GetAccountInfoRequest
-} from "../generated/get_account_info_request_pb";
+export { GetAccountInfoRequest } from "../generated/get_account_info_request_pb";
 export { GetFeeRequest } from "../generated/get_fee_request_pb";
+export { GetTransactionStatusRequest } from "../generated/get_transaction_status_request_pb";
 export { Payment } from "../generated/payment_pb";
-export {
-  SubmitSignedTransactionRequest
-} from "../generated/submit_signed_transaction_request_pb";
-export {
-  SubmitSignedTransactionResponse
-} from "../generated/submit_signed_transaction_response_pb";
+export { SubmitSignedTransactionRequest } from "../generated/submit_signed_transaction_request_pb";
+export { SubmitSignedTransactionResponse } from "../generated/submit_signed_transaction_response_pb";
 export { XRPAmount } from "../generated/xrp_amount_pb";
 export { SignedTransaction } from "../generated/signed_transaction_pb";
 export { default as Signer } from "../src/signer";
+export { TransactionStatus } from "../generated/transaction_status_pb";
 export { Transaction } from "../generated/transaction_pb";
 
 export { default as Wallet } from "./wallet";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,21 +3,13 @@ export { Currency } from "../generated/currency_pb";
 export { Fee } from "../generated/fee_pb";
 export { FiatAmount } from "../generated/fiat_amount_pb";
 export { GetLatestValidatedLedgerSequenceRequest } from "../generated/get_latest_validated_ledger_sequence_request_pb";
-export {
-  GetAccountInfoRequest
-} from "../generated/get_account_info_request_pb";
+export { GetAccountInfoRequest } from "../generated/get_account_info_request_pb";
 export { GetFeeRequest } from "../generated/get_fee_request_pb";
-export {
-  GetTransactionStatusRequest
-} from "../generated/get_transaction_status_request_pb";
+export { GetTransactionStatusRequest } from "../generated/get_transaction_status_request_pb";
 export { LedgerSequence } from "../generated/ledger_sequence_pb";
 export { Payment } from "../generated/payment_pb";
-export {
-  SubmitSignedTransactionRequest
-} from "../generated/submit_signed_transaction_request_pb";
-export {
-  SubmitSignedTransactionResponse
-} from "../generated/submit_signed_transaction_response_pb";
+export { SubmitSignedTransactionRequest } from "../generated/submit_signed_transaction_request_pb";
+export { SubmitSignedTransactionResponse } from "../generated/submit_signed_transaction_response_pb";
 export { XRPAmount } from "../generated/xrp_amount_pb";
 export { SignedTransaction } from "../generated/signed_transaction_pb";
 export { default as Signer } from "../src/signer";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,12 @@ export {
 } from "../generated/get_transaction_status_request_pb";
 export { LedgerSequence } from "../generated/ledger_sequence_pb";
 export { Payment } from "../generated/payment_pb";
-export { SubmitSignedTransactionRequest } from "../generated/submit_signed_transaction_request_pb";
-export { SubmitSignedTransactionResponse } from "../generated/submit_signed_transaction_response_pb";
+export {
+  SubmitSignedTransactionRequest
+} from "../generated/submit_signed_transaction_request_pb";
+export {
+  SubmitSignedTransactionResponse
+} from "../generated/submit_signed_transaction_response_pb";
 export { XRPAmount } from "../generated/xrp_amount_pb";
 export { SignedTransaction } from "../generated/signed_transaction_pb";
 export { default as Signer } from "../src/signer";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,24 @@ export { AccountInfo } from "../generated/account_info_pb";
 export { Currency } from "../generated/currency_pb";
 export { Fee } from "../generated/fee_pb";
 export { FiatAmount } from "../generated/fiat_amount_pb";
-export { GetAccountInfoRequest } from "../generated/get_account_info_request_pb";
+export {
+  GetLatestValidatedLedgerSequenceRequest
+} from "../generated/get_latest_validated_ledger_sequence_request_pb";
+export {
+  GetAccountInfoRequest
+} from "../generated/get_account_info_request_pb";
 export { GetFeeRequest } from "../generated/get_fee_request_pb";
-export { GetTransactionStatusRequest } from "../generated/get_transaction_status_request_pb";
+export {
+  GetTransactionStatusRequest
+} from "../generated/get_transaction_status_request_pb";
+export { LedgerSequence } from "../generated/ledger_sequence_pb";
 export { Payment } from "../generated/payment_pb";
-export { SubmitSignedTransactionRequest } from "../generated/submit_signed_transaction_request_pb";
-export { SubmitSignedTransactionResponse } from "../generated/submit_signed_transaction_response_pb";
+export {
+  SubmitSignedTransactionRequest
+} from "../generated/submit_signed_transaction_request_pb";
+export {
+  SubmitSignedTransactionResponse
+} from "../generated/submit_signed_transaction_response_pb";
 export { XRPAmount } from "../generated/xrp_amount_pb";
 export { SignedTransaction } from "../generated/signed_transaction_pb";
 export { default as Signer } from "../src/signer";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,7 @@ export { AccountInfo } from "../generated/account_info_pb";
 export { Currency } from "../generated/currency_pb";
 export { Fee } from "../generated/fee_pb";
 export { FiatAmount } from "../generated/fiat_amount_pb";
-export {
-  GetLatestValidatedLedgerSequenceRequest
-} from "../generated/get_latest_validated_ledger_sequence_request_pb";
+export { GetLatestValidatedLedgerSequenceRequest } from "../generated/get_latest_validated_ledger_sequence_request_pb";
 export {
   GetAccountInfoRequest
 } from "../generated/get_account_info_request_pb";

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -34,9 +34,7 @@ class Serializer {
     // Convert fields names where direct conversion is possible.
     this.convertPropertyName("sequence", "Sequence", object);
     this.convertPropertyName("signingPublicKeyHex", "SigningPubKey", object);
-    console.log("HIT LINKED CODE3");
     this.convertPropertyName("lastLedgerSequence", "LastLedgerSequence", object);
-    // delete object.lastLedgerSequence;
 
     // Convert account field, handling X-Addresses if needed.
     const account = transaction.getAccount();

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -34,7 +34,11 @@ class Serializer {
     // Convert fields names where direct conversion is possible.
     this.convertPropertyName("sequence", "Sequence", object);
     this.convertPropertyName("signingPublicKeyHex", "SigningPubKey", object);
-    this.convertPropertyName("lastLedgerSequence", "LastLedgerSequence", object);
+    this.convertPropertyName(
+      "lastLedgerSequence",
+      "LastLedgerSequence",
+      object
+    );
 
     // Convert account field, handling X-Addresses if needed.
     const account = transaction.getAccount();

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -34,6 +34,9 @@ class Serializer {
     // Convert fields names where direct conversion is possible.
     this.convertPropertyName("sequence", "Sequence", object);
     this.convertPropertyName("signingPublicKeyHex", "SigningPubKey", object);
+    console.log("HIT LINKED CODE3");
+    this.convertPropertyName("lastLedgerSequence", "LastLedgerSequence", object);
+    // delete object.lastLedgerSequence;
 
     // Convert account field, handling X-Addresses if needed.
     const account = transaction.getAccount();

--- a/test/serializer-test.ts
+++ b/test/serializer-test.ts
@@ -7,6 +7,7 @@ import { XRPAmount } from "../build/generated/xrp_amount_pb";
 import { assert } from "chai";
 import "mocha";
 import Utils from "../src/utils";
+const rippleCodec = require("ripple-binary-codec");
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
@@ -18,7 +19,8 @@ describe("serializer", function(): void {
     const fee = "10";
     const sequence = 1;
     const account = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ";
-    const publicKey = "testPublicKey";
+    const publicKey =
+      "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
 
     const paymentAmount = new XRPAmount();
     paymentAmount.setDrops(value);
@@ -60,7 +62,8 @@ describe("serializer", function(): void {
     const fee = "10";
     const sequence = 1;
     const account = "XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc";
-    const publicKey = "testPublicKey";
+    const publicKey =
+      "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
 
     const paymentAmount = new XRPAmount();
     paymentAmount.setDrops(value);
@@ -88,6 +91,7 @@ describe("serializer", function(): void {
       Amount: value.toString(),
       Destination: destination,
       Fee: fee,
+      LastLedgerSequence: 0,
       Sequence: sequence,
       TransactionType: "Payment",
       SigningPubKey: publicKey
@@ -102,7 +106,8 @@ describe("serializer", function(): void {
     const fee = "10";
     const sequence = 1;
     const account = "XVPcpSm47b1CZkf5AkKM9a84dQHe3mTAxgxfLw2qYoe7Boa";
-    const publicKey = "testPublicKey";
+    const publicKey =
+      "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
 
     const paymentAmount = new XRPAmount();
     paymentAmount.setDrops(value);
@@ -134,7 +139,8 @@ describe("serializer", function(): void {
     const destination = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh";
     const fee = "10";
     const sequence = 1;
-    const publicKey = "testPublicKey";
+    const publicKey =
+      "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
 
     const paymentAmount = new XRPAmount();
     paymentAmount.setDrops(value);
@@ -166,7 +172,8 @@ describe("serializer", function(): void {
     const fee = "10";
     const sequence = 1;
     const account = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ";
-    const publicKey = "testPublicKey";
+    const publicKey =
+      "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
 
     const paymentAmount = new XRPAmount();
     paymentAmount.setDrops(value);
@@ -195,6 +202,7 @@ describe("serializer", function(): void {
       Destination: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1",
       DestinationTag: 12345,
       Fee: fee,
+      LastLedgerSequence: 0,
       Sequence: sequence,
       TransactionType: "Payment",
       SigningPubKey: publicKey
@@ -209,7 +217,8 @@ describe("serializer", function(): void {
     const fee = "10";
     const sequence = 1;
     const account = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ";
-    const publicKey = "testPublicKey";
+    const publicKey =
+      "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
 
     const paymentAmount = new XRPAmount();
     paymentAmount.setDrops(value);
@@ -237,6 +246,7 @@ describe("serializer", function(): void {
       Amount: value.toString(),
       Destination: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1",
       Fee: fee,
+      LastLedgerSequence: 0,
       Sequence: sequence,
       TransactionType: "Payment",
       SigningPubKey: publicKey
@@ -252,7 +262,8 @@ describe("serializer", function(): void {
     const fee = "10";
     const sequence = 1;
     const account = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ";
-    const publicKey = "testPublicKey";
+    const publicKey =
+      "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
 
     const paymentAmount = new FiatAmount();
     paymentAmount.setIssuer(issuer);
@@ -272,6 +283,7 @@ describe("serializer", function(): void {
     transaction.setSequence(sequence);
     transaction.setPayment(payment);
     transaction.setSigningPublicKeyHex(publicKey);
+    transaction.setLastLedgerSequence(10);
 
     // WHEN the transaction is serialized to JSON.
     const serialized = Serializer.transactionToJSON(transaction);
@@ -286,10 +298,18 @@ describe("serializer", function(): void {
       },
       Destination: destination,
       Fee: fee,
+      // LastLedgerSequence: 10,
       Sequence: sequence,
       TransactionType: "Payment",
       SigningPubKey: publicKey
     };
-    assert.deepEqual(serialized, expectedJSON);
+    // assert.deepEqual(serialized, expectedJSON);
+
+    console.log("begin encoding");
+    const encoded = rippleCodec.encodeForSigning(serialized);
+    console.log("encoded! " + JSON.stringify(encoded));
+
+    const decoded = rippleCodec.decode(encoded);
+    assert.deepEqual(decoded, expectedJSON);
   });
 });

--- a/test/serializer-test.ts
+++ b/test/serializer-test.ts
@@ -7,7 +7,6 @@ import { XRPAmount } from "../build/generated/xrp_amount_pb";
 import { assert } from "chai";
 import "mocha";
 import Utils from "../src/utils";
-const rippleCodec = require("ripple-binary-codec");
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 

--- a/test/serializer-test.ts
+++ b/test/serializer-test.ts
@@ -17,6 +17,7 @@ describe("serializer", function(): void {
     const value = "1000";
     const destination = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh";
     const fee = "10";
+    const lastLedgerSequence = 20;
     const sequence = 1;
     const account = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ";
     const publicKey =
@@ -38,6 +39,7 @@ describe("serializer", function(): void {
     transaction.setSequence(sequence);
     transaction.setPayment(payment);
     transaction.setSigningPublicKeyHex(publicKey);
+    transaction.setLastLedgerSequence(lastLedgerSequence);
 
     // WHEN the transaction is serialized to JSON.
     const serialized = Serializer.transactionToJSON(transaction);
@@ -48,6 +50,7 @@ describe("serializer", function(): void {
       Amount: value.toString(),
       Destination: destination,
       Fee: fee,
+      LastLedgerSequence: lastLedgerSequence,
       Sequence: sequence,
       TransactionType: "Payment",
       SigningPubKey: publicKey
@@ -60,6 +63,7 @@ describe("serializer", function(): void {
     const value = "1000";
     const destination = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh";
     const fee = "10";
+    const lastLedgerSequence = 20;
     const sequence = 1;
     const account = "XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc";
     const publicKey =
@@ -81,6 +85,7 @@ describe("serializer", function(): void {
     transaction.setSequence(sequence);
     transaction.setPayment(payment);
     transaction.setSigningPublicKeyHex(publicKey);
+    transaction.setLastLedgerSequence(lastLedgerSequence);
 
     // WHEN the transaction is serialized to JSON.
     const serialized = Serializer.transactionToJSON(transaction);
@@ -91,7 +96,7 @@ describe("serializer", function(): void {
       Amount: value.toString(),
       Destination: destination,
       Fee: fee,
-      LastLedgerSequence: 0,
+      LastLedgerSequence: lastLedgerSequence,
       Sequence: sequence,
       TransactionType: "Payment",
       SigningPubKey: publicKey
@@ -104,6 +109,7 @@ describe("serializer", function(): void {
     const value = "1000";
     const destination = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh";
     const fee = "10";
+    const lastLedgerSequence = 20;
     const sequence = 1;
     const account = "XVPcpSm47b1CZkf5AkKM9a84dQHe3mTAxgxfLw2qYoe7Boa";
     const publicKey =
@@ -125,6 +131,7 @@ describe("serializer", function(): void {
     transaction.setSequence(sequence);
     transaction.setPayment(payment);
     transaction.setSigningPublicKeyHex(publicKey);
+    transaction.setLastLedgerSequence(lastLedgerSequence);
 
     // WHEN the transaction is serialized to JSON.
     const serialized = Serializer.transactionToJSON(transaction);
@@ -138,6 +145,7 @@ describe("serializer", function(): void {
     const value = "1000";
     const destination = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh";
     const fee = "10";
+    const lastLedgerSequence = 20;
     const sequence = 1;
     const publicKey =
       "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE";
@@ -157,6 +165,7 @@ describe("serializer", function(): void {
     transaction.setSequence(sequence);
     transaction.setPayment(payment);
     transaction.setSigningPublicKeyHex(publicKey);
+    transaction.setLastLedgerSequence(lastLedgerSequence);
 
     // WHEN the transaction is serialized to JSON.
     const serialized = Serializer.transactionToJSON(transaction);
@@ -170,6 +179,7 @@ describe("serializer", function(): void {
     const value = "1000";
     const destination = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT";
     const fee = "10";
+    const lastLedgerSequence = 20;
     const sequence = 1;
     const account = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ";
     const publicKey =
@@ -191,6 +201,7 @@ describe("serializer", function(): void {
     transaction.setSequence(sequence);
     transaction.setPayment(payment);
     transaction.setSigningPublicKeyHex(publicKey);
+    transaction.setLastLedgerSequence(lastLedgerSequence);
 
     // WHEN the transaction is serialized to JSON.
     const serialized = Serializer.transactionToJSON(transaction);
@@ -202,7 +213,7 @@ describe("serializer", function(): void {
       Destination: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1",
       DestinationTag: 12345,
       Fee: fee,
-      LastLedgerSequence: 0,
+      LastLedgerSequence: lastLedgerSequence,
       Sequence: sequence,
       TransactionType: "Payment",
       SigningPubKey: publicKey
@@ -215,6 +226,7 @@ describe("serializer", function(): void {
     const value = "1000";
     const destination = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH";
     const fee = "10";
+    const lastLedgerSequence = 20;
     const sequence = 1;
     const account = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ";
     const publicKey =
@@ -236,6 +248,7 @@ describe("serializer", function(): void {
     transaction.setSequence(sequence);
     transaction.setPayment(payment);
     transaction.setSigningPublicKeyHex(publicKey);
+    transaction.setLastLedgerSequence(lastLedgerSequence);
 
     // WHEN the transaction is serialized to JSON.
     const serialized = Serializer.transactionToJSON(transaction);
@@ -246,7 +259,7 @@ describe("serializer", function(): void {
       Amount: value.toString(),
       Destination: "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1",
       Fee: fee,
-      LastLedgerSequence: 0,
+      LastLedgerSequence: lastLedgerSequence,
       Sequence: sequence,
       TransactionType: "Payment",
       SigningPubKey: publicKey
@@ -260,6 +273,7 @@ describe("serializer", function(): void {
     const value = "153.75";
     const destination = "rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh";
     const fee = "10";
+    const lastLedgerSequence = 20;
     const sequence = 1;
     const account = "r9LqNeG6qHxjeUocjvVki2XR35weJ9mZgQ";
     const publicKey =
@@ -283,7 +297,7 @@ describe("serializer", function(): void {
     transaction.setSequence(sequence);
     transaction.setPayment(payment);
     transaction.setSigningPublicKeyHex(publicKey);
-    transaction.setLastLedgerSequence(10);
+    transaction.setLastLedgerSequence(lastLedgerSequence);
 
     // WHEN the transaction is serialized to JSON.
     const serialized = Serializer.transactionToJSON(transaction);
@@ -298,18 +312,11 @@ describe("serializer", function(): void {
       },
       Destination: destination,
       Fee: fee,
-      // LastLedgerSequence: 10,
+      LastLedgerSequence: lastLedgerSequence,
       Sequence: sequence,
       TransactionType: "Payment",
       SigningPubKey: publicKey
     };
-    // assert.deepEqual(serialized, expectedJSON);
-
-    console.log("begin encoding");
-    const encoded = rippleCodec.encodeForSigning(serialized);
-    console.log("encoded! " + JSON.stringify(encoded));
-
-    const decoded = rippleCodec.decode(encoded);
-    assert.deepEqual(decoded, expectedJSON);
+    assert.deepEqual(serialized, expectedJSON);
   });
 });

--- a/test/signer-test.ts
+++ b/test/signer-test.ts
@@ -18,7 +18,7 @@ describe("signer", function(): void {
     const value = "1000";
     const destination = "XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc";
     const fee = "10";
-    const sequence = 1;
+    const sequence = 4;
     const account = "X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4";
 
     const paymentAmount = new XRPAmount();

--- a/test/signer-test.ts
+++ b/test/signer-test.ts
@@ -18,7 +18,7 @@ describe("signer", function(): void {
     const value = "1000";
     const destination = "XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc";
     const fee = "10";
-    const sequence = 4;
+    const sequence = 1;
     const account = "X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4";
 
     const paymentAmount = new XRPAmount();


### PR DESCRIPTION
Specifically:
- Export request / response object for `getTransactionStatus` and `getLastValidatedLedger` RPCs
- Add support for `LastLedgerSequence` field of `Transaction` proto in `Serializer` class. 

I was able to use `npm link` to link these classes into AppianJS and build transactions that were successfully submitted to the ledger and either:
- failed to validate (`lastLedgerSequence` in the past)
- validated (`lastLedgerSequence` in the future) 