### PR TITLE
Run `npm build` as part of Continuous Integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       - run: npm run webpack
-
+      - run: npm run build
       - run: nyc npm test
       
       - run:


### PR DESCRIPTION
`npm run webpack` -> Webpacks typescript to browserified JS
`npm run build` -> Compiles typescript to node JS
`npm test` -> Runs tests in Typescript

