### PR TITLE
Create a seed and derivation path initializer

### DIFF
--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -83,7 +83,7 @@ class Wallet {
 
   /**
    * Generate a new hierarchical deterministic wallet from a seed and derivation path.
-   * 
+   *
    * @param {string} seed The seed for the wallet.
    * @param {string} derivationPath The derivation path to use. If undefined, the default path is used.
    * @returns {Wallet|undefined} A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -78,6 +78,20 @@ class Wallet {
     }
 
     const seed = bip39.mnemonicToSeedSync(mnemonic);
+    return this.generateHDWalletFromSeed(seed, derivationPath);
+  }
+
+  /**
+   * Generate a new hierarchical deterministic wallet from a seed and derivation path.
+   * 
+   * @param {string} seed The seed for the wallet.
+   * @param {string} derivationPath The derivation path to use. If undefined, the default path is used.
+   * @returns {Wallet|undefined} A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
+   */
+  public static generateHDWalletFromSeed(
+    seed: string,
+    derivationPath = Wallet.getDefaultDerivationPath()
+  ): Wallet | undefined {
     const masterNode = bip32.fromSeed(seed);
     const node = masterNode.derivePath(derivationPath);
     const publicKey = Wallet.hexFromBuffer(node.publicKey);

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -41,7 +41,7 @@ class Wallet {
    * Secure random number generation is used when entropy is ommitted and when the runtime environment has the necessary support. Otherwise, an error is thrown. Runtime environments that do not have secure random number generation should pass their own buffer of entropy.
    *
    * @param  {string|undefined} entropy A optional hex string of entropy.
-   * @returns {WalletGenerationResult} Artifacts from the wallet generation..
+   * @returns {WalletGenerationResult} Artifacts from the wallet generation.
    */
   public static generateRandomWallet(
     entropy: string | undefined = undefined
@@ -64,8 +64,8 @@ class Wallet {
   /**
    * Generate a new hierarchical deterministic wallet from a mnemonic and derivation path.
    *
-   * @param {string} mnemonic The mnemonic for the wallet.
-   * @param {string} derivationPath The derivation path to use. If undefined, the default path is used.
+   * @param {string} mnemonic The given mnemonic for the wallet.
+   * @param {string} derivationPath The given derivation path to use. If undefined, the default path is used.
    * @returns {Wallet|undefined} A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
    */
   public static generateWalletFromMnemonic(
@@ -84,8 +84,8 @@ class Wallet {
   /**
    * Generate a new hierarchical deterministic wallet from a seed and derivation path.
    *
-   * @param {string} seed The seed for the wallet.
-   * @param {string} derivationPath The derivation path to use. If undefined, the default path is used.
+   * @param {string} seed The given seed for the wallet.
+   * @param {string} derivationPath The given derivation path to use. If undefined, the default path is used.
    * @returns {Wallet|undefined} A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
    */
   public static generateHDWalletFromSeed(
@@ -102,7 +102,7 @@ class Wallet {
   /**
    * Generate a new wallet from the given seed.
    *
-   * @param {string} seed The seed for the wallet.
+   * @param {string} seed The given seed for the wallet.
    * @returns {Wallet|undefined} A new wallet from the given seed, or undefined if the seed was invalid.
    */
   public static generateWalletFromSeed(seed: string): Wallet | undefined {
@@ -117,8 +117,8 @@ class Wallet {
   /**
    * Create a new Wallet object.
    *
-   * @param {string} publicKey The public key for the wallet.
-   * @param {string} privateKey The private key for the wallet.
+   * @param {string} publicKey The given public key for the wallet.
+   * @param {string} privateKey The given private key for the wallet.
    */
   public constructor(
     private readonly publicKey: string,


### PR DESCRIPTION
Mnemonics and seeds are just different encodings for the same entropy buffer. Create a new initializer which allows users to create a HD wallet with a seed instead of forcing a mnemonic. 