### PR TITLE
Pass through `testnet` parameter when Decoding X-Addresses

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,6 +20,9 @@ export interface ClassicAddress {
 
   /** An optional tag. */
   tag?: number;
+
+  /** A boolean indicating whether this address is on TestNet. */
+  isTestNet: boolean;
 }
 
 class Utils {
@@ -104,7 +107,8 @@ class Utils {
     let shimClassicAddress = addressCodec.xAddressToClassicAddress(xAddress);
     return {
       address: shimClassicAddress.classicAddress,
-      tag: shimClassicAddress.tag !== false ? shimClassicAddress.tag : undefined
+      tag: shimClassicAddress.tag !== false ? shimClassicAddress.tag : undefined,
+      isTestNet: shimClassicAddress.test
     };
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,8 +21,8 @@ export interface ClassicAddress {
   /** An optional tag. */
   tag?: number;
 
-  /** A boolean indicating whether this address is on TestNet. */
-  isTestNet: boolean;
+  /** A boolean indicating whether this address is for use on a test network. */
+  test: boolean;
 }
 
 class Utils {
@@ -108,7 +108,7 @@ class Utils {
     return {
       address: shimClassicAddress.classicAddress,
       tag: shimClassicAddress.tag !== false ? shimClassicAddress.tag : undefined,
-      isTestNet: shimClassicAddress.test
+      test: shimClassicAddress.test
     };
   }
 

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -145,7 +145,7 @@ describe("utils", function(): void {
     // Then the decoded address and tag as are expected.
     assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
     assert.strictEqual(classicAddress!.tag, 12345);
-    assert.strictEqual(classicAddress!.isTestNet, false);
+    assert.strictEqual(classicAddress!.test, false);
   });
 
 
@@ -159,7 +159,7 @@ describe("utils", function(): void {
     // Then the decoded address and tag as are expected.
     assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
     assert.strictEqual(classicAddress!.tag, 12345);
-    assert.strictEqual(classicAddress!.isTestNet, true);
+    assert.strictEqual(classicAddress!.test, true);
   });
 
   it("decodeXAddress() - Valid Address without Tag", function(): void {

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -135,16 +135,31 @@ describe("utils", function(): void {
     assert.isUndefined(xAddress);
   });
 
-  it("decodeXAddress() - Valid Address with Tag", function(): void {
+  it("decodeXAddress() - Valid Mainnet Address with Tag", function(): void {
     // GIVEN an x-address that encodes an address and a tag.
     const address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT";
 
     // WHEN it is decoded to an classic address
-    const xAddress = Utils.decodeXAddress(address);
+    const classicAddress = Utils.decodeXAddress(address);
 
     // Then the decoded address and tag as are expected.
-    assert.strictEqual(xAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
-    assert.strictEqual(xAddress!.tag, 12345);
+    assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.strictEqual(classicAddress!.tag, 12345);
+    assert.strictEqual(classicAddress!.isTestNet, false);
+  });
+
+
+  it("decodeXAddress() - Valid Testnet Address with Tag", function(): void {
+    // GIVEN an x-address that encodes an address and a tag.
+    const address = "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh";
+
+    // WHEN it is decoded to an classic address
+    const classicAddress = Utils.decodeXAddress(address);
+
+    // Then the decoded address and tag as are expected.
+    assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.strictEqual(classicAddress!.tag, 12345);
+    assert.strictEqual(classicAddress!.isTestNet, true);
   });
 
   it("decodeXAddress() - Valid Address without Tag", function(): void {
@@ -152,11 +167,11 @@ describe("utils", function(): void {
     const address = "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUFyQVMzRrMGUZpokKH";
 
     // WHEN it is decoded to an classic address
-    const xAddress = Utils.decodeXAddress(address);
+    const classicAddress = Utils.decodeXAddress(address);
 
     // Then the decoded address and tag as are expected.
-    assert.strictEqual(xAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
-    assert.isUndefined(xAddress!.tag);
+    assert.strictEqual(classicAddress!.address, "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1");
+    assert.isUndefined(classicAddress!.tag);
   });
 
   it("decodeXAddress() - Invalid Address", function(): void {
@@ -164,10 +179,10 @@ describe("utils", function(): void {
     const address = "xrp";
 
     // WHEN it is decoded to an classic address
-    const xAddress = Utils.decodeXAddress(address);
+    const classicAddress = Utils.decodeXAddress(address);
 
     // Then the decoded address is undefined.
-    assert.isUndefined(xAddress);
+    assert.isUndefined(classicAddress);
   });
 
   it("isValidXAddress() - Valid X-Address", function(): void {


### PR DESCRIPTION
Currently, the `test` parameter is dropped when decoding X-Addresses. Pass this data through to clients rather than dropping it. 

Tested:
- Unit tests

Note that the unit test case is derived from manually checking values on http://xrpaddress.info.