### PR TITLE
Add `testnet` parameter when Encoding X-Addresses

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,11 +70,13 @@ class Utils {
    *
    * @param classicAddress A classic address to encode.
    * @param tag An optional tag to encode.
+   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
    * @returns A new x-address if inputs were valid, otherwise undefined.
    */
   public static encodeXAddress(
     classicAddress: string,
-    tag: number | undefined
+    tag: number | undefined,
+    isTestNet: boolean = false
   ): string | undefined {
     if (!addressCodec.isValidClassicAddress(classicAddress)) {
       return undefined;
@@ -84,7 +86,8 @@ class Utils {
     const shimTagParameter = tag !== undefined ? tag : false;
     return addressCodec.classicAddressToXAddress(
       classicAddress,
-      shimTagParameter
+      shimTagParameter,
+      isTestNet
     );
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,13 +70,13 @@ class Utils {
    *
    * @param classicAddress A classic address to encode.
    * @param tag An optional tag to encode.
-   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
+   * @param test Whether the address is for use on a test network, defaults to `false`.
    * @returns A new x-address if inputs were valid, otherwise undefined.
    */
   public static encodeXAddress(
     classicAddress: string,
     tag: number | undefined,
-    isTestNet: boolean = false
+    test: boolean = false
   ): string | undefined {
     if (!addressCodec.isValidClassicAddress(classicAddress)) {
       return undefined;
@@ -87,7 +87,7 @@ class Utils {
     return addressCodec.classicAddressToXAddress(
       classicAddress,
       shimTagParameter,
-      isTestNet
+      test
     );
   }
 

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -99,10 +99,10 @@ describe("utils", function(): void {
     // GIVEN a valid classic address on MainNet and a tag.
     const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
     const tag = 12345;
-    const isTestNet = false;
+    const isTest = false;
 
     // WHEN they are encoded to an x-address.
-    const xAddress = Utils.encodeXAddress(address, tag, isTestNet);
+    const xAddress = Utils.encodeXAddress(address, tag, isTest);
 
     // THEN the result is as expected.
     assert.strictEqual(
@@ -115,10 +115,10 @@ describe("utils", function(): void {
     // GIVEN a valid classic address on TestNet and a tag.
     const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
     const tag = 12345;
-    const isTestNet = true;
+    const isTest = true;
 
     // WHEN they are encoded to an x-address.
-    const xAddress = Utils.encodeXAddress(address, tag, isTestNet);
+    const xAddress = Utils.encodeXAddress(address, tag, isTest);
 
     // THEN the result is as expected.
     assert.strictEqual(

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -95,18 +95,35 @@ describe("utils", function(): void {
     assert.isFalse(validAddress);
   });
 
-  it("encodeXAddress() - Address and Tag", function(): void {
-    // GIVEN a valid classic address and a tag.
+  it("encodeXAddress() - Mainnet Address and Tag", function(): void {
+    // GIVEN a valid classic address on MainNet and a tag.
     const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
     const tag = 12345;
+    const isTestNet = false;
 
     // WHEN they are encoded to an x-address.
-    const xAddress = Utils.encodeXAddress(address, tag);
+    const xAddress = Utils.encodeXAddress(address, tag, isTestNet);
 
     // THEN the result is as expected.
     assert.strictEqual(
       xAddress,
       "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"
+    );
+  });
+
+  it("encodeXAddress() - TestNet Address and Tag", function(): void {
+    // GIVEN a valid classic address on TestNet and a tag.
+    const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+    const tag = 12345;
+    const isTestNet = true;
+
+    // WHEN they are encoded to an x-address.
+    const xAddress = Utils.encodeXAddress(address, tag, isTestNet);
+
+    // THEN the result is as expected.
+    assert.strictEqual(
+      xAddress,
+      "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh"
     );
   });
 


### PR DESCRIPTION
X-Addresses support a special format for TestNet. Xpring-Common-JS currently ignores this parameter and defaults everything to mainnet. 

Add support for this parameter. Make the parameter optional and default to mainnnet. This is because I think:
- Most folks will just want mainnet addresses by default
- The behavior of existing code won't change, so we can release this as a point fix

Tested:
- Unit tests

Note that the unit test case is derived from manually checking values on http://xrpaddress.info.