### PR TITLE
Pass through `testnet` parameter when creating Wallets

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -70,11 +70,13 @@ class Utils {
    *
    * @param classicAddress A classic address to encode.
    * @param tag An optional tag to encode.
+   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
    * @returns A new x-address if inputs were valid, otherwise undefined.
    */
   public static encodeXAddress(
     classicAddress: string,
-    tag: number | undefined
+    tag: number | undefined,
+    isTestNet: boolean = false
   ): string | undefined {
     if (!addressCodec.isValidClassicAddress(classicAddress)) {
       return undefined;
@@ -84,7 +86,8 @@ class Utils {
     const shimTagParameter = tag !== undefined ? tag : false;
     return addressCodec.classicAddressToXAddress(
       classicAddress,
-      shimTagParameter
+      shimTagParameter,
+      isTestNet
     );
   }
 

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -41,12 +41,12 @@ class Wallet {
    * Secure random number generation is used when entropy is ommitted and when the runtime environment has the necessary support. Otherwise, an error is thrown. Runtime environments that do not have secure random number generation should pass their own buffer of entropy.
    *
    * @param entropy A optional hex string of entropy.
-   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
+   * @param test Whether the address is for use on a test network, defaults to `false`.
    * @returns Artifacts from the wallet generation.
    */
   public static generateRandomWallet(
     entropy: string | undefined = undefined,
-    isTestNet: boolean = false
+    test: boolean = false
   ): WalletGenerationResult | undefined {
     if (entropy && !Utils.isHex(entropy)) {
       return undefined;
@@ -57,7 +57,7 @@ class Wallet {
         ? bip39.generateMnemonic()
         : bip39.entropyToMnemonic(entropy);
     const derivationPath = Wallet.getDefaultDerivationPath();
-    const wallet = Wallet.generateWalletFromMnemonic(mnemonic, derivationPath, isTestNet);
+    const wallet = Wallet.generateWalletFromMnemonic(mnemonic, derivationPath, test);
     return wallet == undefined
       ? undefined
       : { wallet: wallet, mnemonic: mnemonic, derivationPath: derivationPath };
@@ -68,13 +68,13 @@ class Wallet {
    *
    * @param mnemonic The given mnemonic for the wallet.
    * @param derivationPath The given derivation path to use. If undefined, the default path is used.
-   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
+   * @param test Whether the address is for use on a test network, defaults to `false`.
    * @returns A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
    */
   public static generateWalletFromMnemonic(
     mnemonic: string,
     derivationPath = Wallet.getDefaultDerivationPath(),
-    isTestNet: boolean = false
+    test: boolean = false
   ): Wallet | undefined {
     // Validate mnemonic and path are valid.
     if (!bip39.validateMnemonic(mnemonic)) {
@@ -82,7 +82,7 @@ class Wallet {
     }
 
     const seed = bip39.mnemonicToSeedSync(mnemonic);
-    return this.generateHDWalletFromSeed(seed, derivationPath, isTestNet);
+    return this.generateHDWalletFromSeed(seed, derivationPath, test);
   }
 
   /**
@@ -90,35 +90,35 @@ class Wallet {
    *
    * @param seed The given seed for the wallet.
    * @param derivationPath The given derivation path to use. If undefined, the default path is used.
-   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
+   * @param test Whether the address is for use on a test network, defaults to `false`.
    * @returns A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
    */
   public static generateHDWalletFromSeed(
     seed: string,
     derivationPath = Wallet.getDefaultDerivationPath(),
-    isTestNet: boolean = false
+    test: boolean = false
   ): Wallet | undefined {
     const masterNode = bip32.fromSeed(seed);
     const node = masterNode.derivePath(derivationPath);
     const publicKey = Wallet.hexFromBuffer(node.publicKey);
     const privateKey = Wallet.hexFromBuffer(node.privateKey);
-    return new Wallet(publicKey, "00" + privateKey, isTestNet);
+    return new Wallet(publicKey, "00" + privateKey, test);
   }
 
   /**
    * Generate a new wallet from the given seed.
    *
    * @param seed The given seed for the wallet.
-   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
+   * @param test Whether the address is for use on a test network, defaults to `false`.
    * @returns A new wallet from the given seed, or undefined if the seed was invalid.
    */
   public static generateWalletFromSeed(
     seed: string,     
-    isTestNet: boolean = false
+    test: boolean = false
   ): Wallet | undefined {
     try {
       const keyPair = rippleKeyPair.deriveKeypair(seed);
-      return new Wallet(keyPair.publicKey, keyPair.privateKey, isTestNet);
+      return new Wallet(keyPair.publicKey, keyPair.privateKey, test);
     } catch (exception) {
       return undefined;
     }
@@ -129,12 +129,12 @@ class Wallet {
    *
    * @param publicKey The given public key for the wallet.
    * @param privateKey The given private key for the wallet.
-   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
+   * @param test Whether the address is for use on a test network, defaults to `false`.
    */
   public constructor(
     private readonly publicKey: string,
     private readonly privateKey: string,
-    private readonly isTestNet: boolean = false
+    private readonly test: boolean = false
   ) {}
 
   /**
@@ -156,7 +156,7 @@ class Wallet {
    */
   public getAddress(): string {
     const classicAddress = rippleKeyPair.deriveAddress(this.getPublicKey());
-    const xAddress = Utils.encodeXAddress(classicAddress, undefined, this.isTestNet);
+    const xAddress = Utils.encodeXAddress(classicAddress, undefined, this.test);
     if (xAddress == undefined) {
       throw new Error("Unknown error deriving address");
     }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -40,11 +40,13 @@ class Wallet {
    *
    * Secure random number generation is used when entropy is ommitted and when the runtime environment has the necessary support. Otherwise, an error is thrown. Runtime environments that do not have secure random number generation should pass their own buffer of entropy.
    *
-   * @param  {string|undefined} entropy A optional hex string of entropy.
-   * @returns {WalletGenerationResult} Artifacts from the wallet generation.
+   * @param entropy A optional hex string of entropy.
+   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
+   * @returns Artifacts from the wallet generation.
    */
   public static generateRandomWallet(
-    entropy: string | undefined = undefined
+    entropy: string | undefined = undefined,
+    isTestNet: boolean = false
   ): WalletGenerationResult | undefined {
     if (entropy && !Utils.isHex(entropy)) {
       return undefined;
@@ -55,7 +57,7 @@ class Wallet {
         ? bip39.generateMnemonic()
         : bip39.entropyToMnemonic(entropy);
     const derivationPath = Wallet.getDefaultDerivationPath();
-    const wallet = Wallet.generateWalletFromMnemonic(mnemonic, derivationPath);
+    const wallet = Wallet.generateWalletFromMnemonic(mnemonic, derivationPath, isTestNet);
     return wallet == undefined
       ? undefined
       : { wallet: wallet, mnemonic: mnemonic, derivationPath: derivationPath };
@@ -64,13 +66,15 @@ class Wallet {
   /**
    * Generate a new hierarchical deterministic wallet from a mnemonic and derivation path.
    *
-   * @param {string} mnemonic The given mnemonic for the wallet.
-   * @param {string} derivationPath The given derivation path to use. If undefined, the default path is used.
-   * @returns {Wallet|undefined} A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
+   * @param mnemonic The given mnemonic for the wallet.
+   * @param derivationPath The given derivation path to use. If undefined, the default path is used.
+   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
+   * @returns A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
    */
   public static generateWalletFromMnemonic(
     mnemonic: string,
-    derivationPath = Wallet.getDefaultDerivationPath()
+    derivationPath = Wallet.getDefaultDerivationPath(),
+    isTestNet: boolean = false
   ): Wallet | undefined {
     // Validate mnemonic and path are valid.
     if (!bip39.validateMnemonic(mnemonic)) {
@@ -78,37 +82,43 @@ class Wallet {
     }
 
     const seed = bip39.mnemonicToSeedSync(mnemonic);
-    return this.generateHDWalletFromSeed(seed, derivationPath);
+    return this.generateHDWalletFromSeed(seed, derivationPath, isTestNet);
   }
 
   /**
    * Generate a new hierarchical deterministic wallet from a seed and derivation path.
    *
-   * @param {string} seed The given seed for the wallet.
-   * @param {string} derivationPath The given derivation path to use. If undefined, the default path is used.
-   * @returns {Wallet|undefined} A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
+   * @param seed The given seed for the wallet.
+   * @param derivationPath The given derivation path to use. If undefined, the default path is used.
+   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
+   * @returns A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
    */
   public static generateHDWalletFromSeed(
     seed: string,
-    derivationPath = Wallet.getDefaultDerivationPath()
+    derivationPath = Wallet.getDefaultDerivationPath(),
+    isTestNet: boolean = false
   ): Wallet | undefined {
     const masterNode = bip32.fromSeed(seed);
     const node = masterNode.derivePath(derivationPath);
     const publicKey = Wallet.hexFromBuffer(node.publicKey);
     const privateKey = Wallet.hexFromBuffer(node.privateKey);
-    return new Wallet(publicKey, "00" + privateKey);
+    return new Wallet(publicKey, "00" + privateKey, isTestNet);
   }
 
   /**
    * Generate a new wallet from the given seed.
    *
-   * @param {string} seed The given seed for the wallet.
-   * @returns {Wallet|undefined} A new wallet from the given seed, or undefined if the seed was invalid.
+   * @param seed The given seed for the wallet.
+   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
+   * @returns A new wallet from the given seed, or undefined if the seed was invalid.
    */
-  public static generateWalletFromSeed(seed: string): Wallet | undefined {
+  public static generateWalletFromSeed(
+    seed: string,     
+    isTestNet: boolean = false
+  ): Wallet | undefined {
     try {
       const keyPair = rippleKeyPair.deriveKeypair(seed);
-      return new Wallet(keyPair.publicKey, keyPair.privateKey);
+      return new Wallet(keyPair.publicKey, keyPair.privateKey, isTestNet);
     } catch (exception) {
       return undefined;
     }
@@ -117,12 +127,14 @@ class Wallet {
   /**
    * Create a new Wallet object.
    *
-   * @param {string} publicKey The given public key for the wallet.
-   * @param {string} privateKey The given private key for the wallet.
+   * @param publicKey The given public key for the wallet.
+   * @param privateKey The given private key for the wallet.
+   * @param isTestNet Whether the address is for use on TestNet, defaults to `false`.
    */
   public constructor(
     private readonly publicKey: string,
-    private readonly privateKey: string
+    private readonly privateKey: string,
+    private readonly isTestNet: boolean = false
   ) {}
 
   /**
@@ -144,7 +156,7 @@ class Wallet {
    */
   public getAddress(): string {
     const classicAddress = rippleKeyPair.deriveAddress(this.getPublicKey());
-    const xAddress = Utils.encodeXAddress(classicAddress, undefined);
+    const xAddress = Utils.encodeXAddress(classicAddress, undefined, this.isTestNet);
     if (xAddress == undefined) {
       throw new Error("Unknown error deriving address");
     }

--- a/test/utils-test.ts
+++ b/test/utils-test.ts
@@ -95,18 +95,35 @@ describe("utils", function(): void {
     assert.isFalse(validAddress);
   });
 
-  it("encodeXAddress() - Address and Tag", function(): void {
-    // GIVEN a valid classic address and a tag.
+  it("encodeXAddress() - Mainnet Address and Tag", function(): void {
+    // GIVEN a valid classic address on MainNet and a tag.
     const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
     const tag = 12345;
+    const isTestNet = false;
 
     // WHEN they are encoded to an x-address.
-    const xAddress = Utils.encodeXAddress(address, tag);
+    const xAddress = Utils.encodeXAddress(address, tag, isTestNet);
 
     // THEN the result is as expected.
     assert.strictEqual(
       xAddress,
       "XVfC9CTCJh6GN2x8bnrw3LtdbqiVCUvtU3HnooQDgBnUpQT"
+    );
+  });
+
+  it("encodeXAddress() - TestNet Address and Tag", function(): void {
+    // GIVEN a valid classic address on TestNet and a tag.
+    const address = "rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1";
+    const tag = 12345;
+    const isTestNet = true;
+
+    // WHEN they are encoded to an x-address.
+    const xAddress = Utils.encodeXAddress(address, tag, isTestNet);
+
+    // THEN the result is as expected.
+    assert.strictEqual(
+      xAddress,
+      "TVsBZmcewpEHgajPi1jApLeYnHPJw82v9JNYf7dkGmWphmh"
     );
   });
 

--- a/test/wallet-test.ts
+++ b/test/wallet-test.ts
@@ -191,10 +191,10 @@ describe("wallet", function(): void {
   it("walletFromSeed - TestNet", function(): void {
     // GIVEN a seed used to generate a wallet on TestNet
     const seed = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
-    const isTestNet = true;
+    const test = true;
 
     // WHEN a wallet is generated from the seed.
-    const wallet = Wallet.generateWalletFromSeed(seed, isTestNet);
+    const wallet = Wallet.generateWalletFromSeed(seed, test);
 
     // THEN the wallet has the expected address.
     assert.equal(

--- a/test/wallet-test.ts
+++ b/test/wallet-test.ts
@@ -17,7 +17,8 @@ const derivationPathTestCases = {
       "031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE",
     expectedPrivateKey:
       "0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4",
-    expectedAddress: "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ",
+    expectedMainNetAddress: "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ",
+    expectedTestNetAddress: "TVHLFWLKvbMv1LFzd6FA2Bf9MPpcy4mRto4VFAAxLuNpvdW",
     messageHex: new Buffer("test message", "utf-8").toString("hex"),
     expectedSignature:
       "3045022100E10177E86739A9C38B485B6AA04BF2B9AA00E79189A1132E7172B70F400ED1170220566BD64AA3F01DDE8D99DFFF0523D165E7DD2B9891ABDA1944E2F3A52CCCB83A"
@@ -36,7 +37,7 @@ const derivationPathTestCases = {
 
 describe("wallet", function(): void {
   it("generateRandomWallet", function(): void {
-    // WHEN a new wallet is generated.
+    // WHEN a new wallet is generated for use on mainnet
     const walletGenerationResult = Wallet.generateRandomWallet();
 
     // THEN the wallet generation artifacts exist and have the default derivation path.
@@ -48,8 +49,8 @@ describe("wallet", function(): void {
     );
   });
 
-  it("generateRandomWallet - entropy", function(): void {
-    // WHEN a new wallet is generated with entropy.
+  it("generateRandomWallet - entropy and mainnet", function(): void {
+    // WHEN a new wallet is generated with entropy on MainNet.
     const walletGenerationResult = Wallet.generateRandomWallet(
       "00000000000000000000000000000000"
     );
@@ -64,6 +65,31 @@ describe("wallet", function(): void {
       walletGenerationResult!.derivationPath,
       Wallet.getDefaultDerivationPath()
     );
+    assert.equal(
+      walletGenerationResult!.wallet.getAddress(), "XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ"
+    )
+  });
+
+  it("generateRandomWallet - entropy and testnet", function(): void {
+    // WHEN a new wallet is generated with entropy on TestNet
+    const walletGenerationResult = Wallet.generateRandomWallet(
+      "00000000000000000000000000000000",
+      true
+    );
+
+    // THEN the result exists and has the default derivation path.
+    assert.exists(walletGenerationResult);
+    assert.equal(
+      walletGenerationResult!.mnemonic,
+      "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    );
+    assert.equal(
+      walletGenerationResult!.derivationPath,
+      Wallet.getDefaultDerivationPath()
+    );
+    assert.equal(
+      walletGenerationResult!.wallet.getAddress(), "TVHLFWLKvbMv1LFzd6FA2Bf9MPpcy4mRto4VFAAxLuNpvdW"
+    )
   });
 
   it("generateRandomWallet - invalid entropy", function(): void {
@@ -74,11 +100,11 @@ describe("wallet", function(): void {
     assert.isUndefined(walletGenerationResult);
   });
 
-  it("walletFromMnemonic - derivation path index 0", function(): void {
+  it("walletFromMnemonic - derivation path index 0 - MainNet", function(): void {
     // GIVEN a menmonic, derivation path and a set of expected outputs.
     const testData = derivationPathTestCases.index0;
 
-    // WHEN a new wallet is generated with the mnemonic and derivation path.
+    // WHEN a new wallet is generated on MainNet with the mnemonic and derivation path.
     const wallet = Wallet.generateWalletFromMnemonic(
       testData.mnemonic,
       testData.derivationPath
@@ -87,7 +113,24 @@ describe("wallet", function(): void {
     // THEN the wallet has the expected address and keys.
     assert.equal(wallet.getPrivateKey(), testData.expectedPrivateKey);
     assert.equal(wallet.getPublicKey(), testData.expectedPublicKey);
-    assert.equal(wallet.getAddress(), testData.expectedAddress);
+    assert.equal(wallet.getAddress(), testData.expectedMainNetAddress);
+  });
+
+  it("walletFromMnemonic - derivation path index 0, TestNet", function(): void {
+    // GIVEN a menmonic, derivation path and a set of expected outputs.
+    const testData = derivationPathTestCases.index0;
+
+    // WHEN a new wallet is generated on TestNet with the mnemonic and derivation path.
+    const wallet = Wallet.generateWalletFromMnemonic(
+      testData.mnemonic,
+      testData.derivationPath,
+      true
+    )!;
+
+    // THEN the wallet has the expected address and keys.
+    assert.equal(wallet.getPrivateKey(), testData.expectedPrivateKey);
+    assert.equal(wallet.getPublicKey(), testData.expectedPublicKey);
+    assert.equal(wallet.getAddress(), testData.expectedTestNetAddress);
   });
 
   it("walletFromMnemonic - derivation path index 1", function(): void {
@@ -116,7 +159,7 @@ describe("wallet", function(): void {
     // THEN the wallet has the expected address and keys from the input mnemonic at the default derivation path.
     assert.equal(wallet.getPrivateKey(), testData.expectedPrivateKey);
     assert.equal(wallet.getPublicKey(), testData.expectedPublicKey);
-    assert.equal(wallet.getAddress(), testData.expectedAddress);
+    assert.equal(wallet.getAddress(), testData.expectedMainNetAddress);
   });
 
   it("walletFromMnemonic - invalid mnemonic", function(): void {
@@ -130,17 +173,33 @@ describe("wallet", function(): void {
     assert.isUndefined(wallet);
   });
 
-  it("walletFromSeed", function(): void {
-    // GIVEN a seed.
+  it("walletFromSeed - MainNet", function(): void {
+    // GIVEN a seed used to generate a wallet on MainNet
     const seed = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
+    const isTestNet = false;
 
     // WHEN a wallet is generated from the seed.
-    const wallet = Wallet.generateWalletFromSeed(seed);
+    const wallet = Wallet.generateWalletFromSeed(seed, isTestNet);
 
     // THEN the wallet has the expected address.
     assert.equal(
       wallet!.getAddress(),
       "XVnJMYQFqA8EAijpKh5EdjEY5JqyxykMKKSbrUX8uchF6U8"
+    );
+  });
+
+  it("walletFromSeed - TestNet", function(): void {
+    // GIVEN a seed used to generate a wallet on TestNet
+    const seed = "snYP7oArxKepd3GPDcrjMsJYiJeJB";
+    const isTestNet = true;
+
+    // WHEN a wallet is generated from the seed.
+    const wallet = Wallet.generateWalletFromSeed(seed, isTestNet);
+
+    // THEN the wallet has the expected address.
+    assert.equal(
+      wallet!.getAddress(),
+      "T7zFmeZo6uLHP4Vd21TpXjrTBk487ZQPGVQsJ1mKWGCD5rq"
     );
   });
 


### PR DESCRIPTION
X-Addresses support a special format for TestNet. Xpring-Common-JS currently ignores this parameter and defaults everything to MainNet.

Add support for this parameter in all initializers and factory methods of the `Wallet` class. Pass through this parameter to the address derivation code. 

Make the parameter optional and default to MainNet. This is because I think:
- Most folks will just want mainnet addresses by default
- The behavior of existing code won't change, so we can release this as a point fix

Tested:
- Unit tests

Note that the unit test case is derived from manually checking values on http://xrpaddress.info.