### PR TITLE
Use class reference to call static method

### DIFF
--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -76,16 +76,12 @@ class Wallet {
     derivationPath = Wallet.getDefaultDerivationPath(),
     test: boolean = false
   ): Wallet | undefined {
-    console.log('calling')
-
     // Validate mnemonic and path are valid.
     if (!bip39.validateMnemonic(mnemonic)) {
-      console.log('ditching (bad mnemonic)')
       return undefined;
     }
 
     const seed = bip39.mnemonicToSeedSync(mnemonic);
-    console.log('got a seed')
 
     return Wallet.generateHDWalletFromSeed(seed, derivationPath, test);
   }
@@ -103,8 +99,6 @@ class Wallet {
     derivationPath = Wallet.getDefaultDerivationPath(),
     test: boolean = false
   ): Wallet | undefined {
-    console.log('called sub function')
-
     const masterNode = bip32.fromSeed(seed);
     const node = masterNode.derivePath(derivationPath);
     const publicKey = Wallet.hexFromBuffer(node.publicKey);

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -76,13 +76,18 @@ class Wallet {
     derivationPath = Wallet.getDefaultDerivationPath(),
     test: boolean = false
   ): Wallet | undefined {
+    console.log('calling')
+
     // Validate mnemonic and path are valid.
     if (!bip39.validateMnemonic(mnemonic)) {
+      console.log('ditching (bad mnemonic)')
       return undefined;
     }
 
     const seed = bip39.mnemonicToSeedSync(mnemonic);
-    return this.generateHDWalletFromSeed(seed, derivationPath, test);
+    console.log('got a seed')
+
+    return Wallet.generateHDWalletFromSeed(seed, derivationPath, test);
   }
 
   /**
@@ -98,6 +103,8 @@ class Wallet {
     derivationPath = Wallet.getDefaultDerivationPath(),
     test: boolean = false
   ): Wallet | undefined {
+    console.log('called sub function')
+
     const masterNode = bip32.fromSeed(seed);
     const node = masterNode.derivePath(derivationPath);
     const publicKey = Wallet.hexFromBuffer(node.publicKey);
@@ -113,7 +120,7 @@ class Wallet {
    * @returns A new wallet from the given seed, or undefined if the seed was invalid.
    */
   public static generateWalletFromSeed(
-    seed: string,     
+    seed: string,
     test: boolean = false
   ): Wallet | undefined {
     try {

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -82,7 +82,6 @@ class Wallet {
     }
 
     const seed = bip39.mnemonicToSeedSync(mnemonic);
-
     return Wallet.generateHDWalletFromSeed(seed, derivationPath, test);
   }
 


### PR DESCRIPTION
Using `this` to call a static method breaks our binding code on iOS. I think that this approach is consistent with the approach we've taken in the file so far and is idiomatic. 