### PR TITLE
[Build Fix] Update Node Version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/node:7.10
+      - image: circleci/node:9
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - protobuf/install
       - run:
           name: "Install dependencies"
-          command: sudo npm -g i nyc npx
+          command: sudo npm -g i nyc
       - save_cache:
           paths:
             - node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/node:9
+      - image: circleci/node:10
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Our dependencies have dropped compatibility for Node 7.X.  Example failure: https://circleci.com/gh/xpring-eng/xpring-common-js/409

Start building with Node 10.0, which is [the LTS release](https://nodejs.org/en/about/releases/). 