### PR TITLE
Implement Signing Methods and Tests for rippled protocol buffers 

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -33,8 +33,7 @@ class Signer {
     }
     const transactionHex = rippleCodec.encodeForSigning(transactionJSON);
 
-    const signatureHex = wallet.sign(transactionHex);
-    return signatureHex;
+    return wallet.sign(transactionHex);
   }
 
   /**

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -2,7 +2,8 @@
 
 import Serializer from "./serializer";
 import { SignedTransaction } from "../generated/legacy/signed_transaction_pb";
-import { Transaction } from "../generated/legacy/transaction_pb";
+import { Transaction as LegacyTransaction } from "../generated/legacy/transaction_pb";
+import { Transaction } from "../generated/rpc/v1/transaction_pb";
 import Wallet from "./wallet";
 
 const rippleCodec = require("ripple-binary-codec");
@@ -14,12 +15,37 @@ class Signer {
   /**
    * Encode the given object to hex and sign it.
    *
+   * @param transaction The transaction to sign.
+   * @param wallet The wallet to sign the transaction with.
+   * @returns A signed transaction.
+   */
+  public static signTransaction(
+    transaction: Transaction,
+    wallet: Wallet
+  ): string | undefined {
+    if (transaction === undefined || wallet === undefined) {
+      return undefined;
+    }
+
+    var transactionJSON = Serializer.transactionToJSON(transaction);
+    if (transactionJSON === undefined) {
+      return undefined;
+    }
+    const transactionHex = rippleCodec.encodeForSigning(transactionJSON);
+
+    const signatureHex = wallet.sign(transactionHex);
+    return signatureHex;
+  }
+
+  /**
+   * Encode the given object to hex and sign it.
+   *
    * @param {Transaction} transaction The transaction to sign.
    * @param {Wallet} wallet The wallet to sign the transaction with.
    * @returns {SignedTransaction} A signed transaction.
    */
   public static signLegacyTransaction(
-    transaction: Transaction,
+    transaction: LegacyTransaction,
     wallet: Wallet
   ): SignedTransaction | undefined {
     if (transaction === undefined || wallet === undefined) {

--- a/test/signer-test.ts
+++ b/test/signer-test.ts
@@ -1,11 +1,13 @@
 import FakeWallet from "./fakes/fake-wallet";
-import { Payment } from "../generated/legacy/payment_pb";
+import { Payment as LegacyPayment } from "../generated/legacy/payment_pb";
 import Signer from "../src/signer";
-import { Transaction } from "../generated/legacy/transaction_pb";
+import { Transaction as LegacyTransaction } from "../generated/legacy/transaction_pb";
 import Utils from "../src/utils";
 import { XRPAmount } from "../generated/legacy/xrp_amount_pb";
 import { assert } from "chai";
 import "mocha";
+import { AccountAddress, CurrencyAmount, XRPDropsAmount } from "../generated/rpc/v1/amount_pb";
+import { Payment, Transaction } from "../generated/rpc/v1/transaction_pb";
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
@@ -24,14 +26,14 @@ describe("signer", function(): void {
     const paymentAmount = new XRPAmount();
     paymentAmount.setDrops(value);
 
-    const payment = new Payment();
+    const payment = new LegacyPayment();
     payment.setDestination(destination);
     payment.setXrpAmount(paymentAmount);
 
     const transactionFee = new XRPAmount();
     transactionFee.setDrops(fee);
 
-    const transaction = new Transaction();
+    const transaction = new LegacyTransaction();
     transaction.setAccount(account);
     transaction.setFee(transactionFee);
     transaction.setSequence(sequence);
@@ -55,4 +57,53 @@ describe("signer", function(): void {
       transaction.toObject()
     );
   });
+
+  it("sign", function(): void {
+    // GIVEN an transaction and a wallet and expected signing artifacts.
+    const fakeSignature = "DEADBEEF";
+    const wallet = new FakeWallet(fakeSignature);
+
+    const value = 1000;
+    const destination = "XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc";
+    const fee = 10;
+    const sequence = 1;
+    const account = "X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4";
+
+    const paymentAmount = new XRPDropsAmount();
+    paymentAmount.setDrops(value);
+
+    const currencyAmount = new CurrencyAmount();
+    currencyAmount.setXrpAmount(paymentAmount);
+
+    const destinationAddress = new AccountAddress();
+    destinationAddress.setAddress(destination)
+
+    const payment = new Payment();
+    payment.setDestination(destinationAddress);
+    payment.setAmount(currencyAmount);
+
+    const transactionFee = new XRPDropsAmount();
+    transactionFee.setDrops(fee);
+
+    const sender = new AccountAddress();
+    sender.setAddress(account)
+
+    const transaction = new Transaction();
+    transaction.setAccount(sender);
+    transaction.setFee(transactionFee);
+    transaction.setSequence(sequence);
+    transaction.setPayment(payment);
+
+    // WHEN the transaction is signed with the wallet.
+    const signature = Signer.signTransaction(transaction, wallet);
+
+    // THEN the signing artifacts are as expected.
+    assert.exists(signature);
+    assert.isTrue(Utils.isHex(signature!));
+    assert.equal(
+      signature,
+      fakeSignature
+    );
+  });
 });
+


### PR DESCRIPTION
rippled is going to implement protocol buffer support natively, which is going to use a set of well reviewed protocol buffers. The implementation in rippled is being done here: https://github.com/ripple/rippled/pull/3159.

xpring-common-js uses protocol buffers as an input to serialization and signing functions. To bridge compatibility, we will:
- [x] [Rename existing functions to have a legacy prefix](https://github.com/xpring-eng/xpring-common-js/pull/124)
- [x] [Add new serialization functions and tests](https://github.com/xpring-eng/xpring-common-js/pull/125)
- [x] Add new signing functions and tests

Afterwards, client libraries will need to get upgraded. This will be a breaking change and should have a minor version number bump when the next release is cut. 