### PR TITLE
Cut Xpring-Common-JS v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The release migrates the protocol buffers in (xpring-common-protocol-buffers)[ht
 
 This release adds support for (protocol buffers in rippled)[https://github.com/ripple/rippled/tree/develop/src/ripple/proto/rpc/v1]. These protocol buffers are the recommended alternative.
 
+The protocol buffers from `rippled` are not compatible with the protocol buffers from `xpring-common-protocol-buffers`. That makes this a *breaking change*. Clients will need to migrate to new methods (see `breaking changes` below).
+
 - Support for rippled protocol buffer serialization and signing.
 - `Serializer`'s `transactionToJSON` method is renamed `legacyTransactionToJSON`. The `transactionToJSON` method now supports protocol buffers from rippled.
 - `Signers`'s `signTransaction` method is renamed to `signLegacyTransaction`. The `signTransaction` method now supports protocol buffers from rippled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,8 @@ This release adds support for (protocol buffers in rippled)[https://github.com/r
 - Support for rippled protocol buffer serialization and signing.
 - `Serializer`'s `transactionToJSON` method is renamed `legacyTransactionToJSON`. The `transactionToJSON` method now supports protocol buffers from rippled.
 - `Signers`'s `signTransaction` method is renamed to `signLegacyTransaction`. The `signTransaction` method now supports protocol buffers from rippled.
+
+### Breaking Changes
+
+- Clients who called `Serializer`'s `transactionToJSON` should migrate to using the `legacyTransactionToJSON` method.
+- Clients who called `Signers`'s `signTransaction` should migrate to using the `signLegacyTransaction` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0] - 2019-02-15
+
+### Added
+
+The release migrates the protocol buffers in (xpring-common-protocol-buffers)[https://github.com/xpring-eng/xpring-common-protocol-buffers) to a 'legacy' namespace. These protocol buffers and methods will be removed at some point in the future.
+
+This release adds support for (protocol buffers in rippled)[https://github.com/ripple/rippled/tree/develop/src/ripple/proto/rpc/v1]. These protocol buffers are the recommended alternative.
+
+- Support for rippled protocol buffer serialization and signing.
+- `Serializer`'s `transactionToJSON` method is renamed `legacyTransactionToJSON`. The `transactionToJSON` method now supports protocol buffers from rippled.
+- `Signers`'s `signTransaction` method is renamed to `signLegacyTransaction`. The `signTransaction` method now supports protocol buffers from rippled.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "1.1.15",
+  "version": "2.0.0",
   "description": "Common JavaScript for use within the Xpring Platform",
   "main": "build/src/index.js",
   "repository": "https://github.com/xpring-eng/xpring-common-js.git",


### PR DESCRIPTION
Version 2.0.0 contains support for serializing new protocol buffers from rippled. Old code was moved to functions named 'Legacy'.

