### PR TITLE
Lock Versions of Protocol Buffer Compilers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Common JavaScript for use within the Xpring Platform",
   "main": "build/src/index.js",
   "repository": "https://github.com/xpring-eng/xpring-common-js.git",
@@ -43,8 +43,8 @@
     "eslint-plugin-import": "2.19.1",
     "eslint-plugin-mocha": "6.2.2",
     "eslint-plugin-prettier": "3.1.2",
-    "grpc-tools": "^1.8.0",
-    "grpc_tools_node_protoc_ts": "^2.5.9",
+    "grpc-tools": "1.8.0",
+    "grpc_tools_node_protoc_ts": "2.5.9",
     "mocha": "7.0.0",
     "nyc": "15.0.0",
     "prettier": "1.19.1",


### PR DESCRIPTION
## High Level Overview of Change

Locks the version of the protocol buffer compilers and cuts a new fix version.

### Context of Change

xpring-common-js has a public API that takes protocol buffers as arguments. xpring-js consumes this API, but generates its own set of protocol buffers.  Because of TypeScript's typing, the generated protocol buffer files in xpring-js and xpring-common-js must stay the same. Therefore, the tools used to generate these files should stay in sync.

Currently, compilation of Xpring-JS is broken because two different versions of the protocol buffer compiler created two different outputs. 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)

## Before / After

CI Passes.

## Test Plan

I used `npm link` to link this in locally to `xpring-js` and ensure it builds.
