### PR TITLE
Changelog for 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
- ## [2.0.1] - 2019-02-15
+## [2.0.1] - 2019-02-15
+
+### Fixed
 
 This patch release locks the versions of `grpc-tools` and `grpc_tools_node_protoc_ts` dependencies. This allows client projects to be able to deterministicly generate compatible protocol buffers with this project's TypeScript. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2019-02-15
 
+This minor release locks the versions of `grpc-tools` and `grpc_tools_node_protoc_ts` dependencies. This allows client projects to be able to deterministicly genereate compatible protocol buffers with this project's TypeScript. 
+
+## [2.0.0] - 2019-02-15
+
 ### Added
 
 The release migrates the protocol buffers in (xpring-common-protocol-buffers)[https://github.com/xpring-eng/xpring-common-protocol-buffers) to a 'legacy' namespace. These protocol buffers and methods will be removed at some point in the future.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0] - 2019-02-15
+ ## [2.0.1] - 2019-02-15
 
 This minor release locks the versions of `grpc-tools` and `grpc_tools_node_protoc_ts` dependencies. This allows client projects to be able to deterministicly genereate compatible protocol buffers with this project's TypeScript. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This patch release locks the versions of `grpc-tools` and `grpc_tools_node_protoc_ts` dependencies. This allows client projects to be able to deterministicly generate compatible protocol buffers with this project's TypeScript. 
 
+Previously, different versions of the protocol buffer compiler would (sometimes) produce slightly different output (generally by renaming fields).
+
 ## [2.0.0] - 2019-02-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  ## [2.0.1] - 2019-02-15
 
-This patch release locks the versions of `grpc-tools` and `grpc_tools_node_protoc_ts` dependencies. This allows client projects to be able to deterministicly genereate compatible protocol buffers with this project's TypeScript. 
+This patch release locks the versions of `grpc-tools` and `grpc_tools_node_protoc_ts` dependencies. This allows client projects to be able to deterministicly generate compatible protocol buffers with this project's TypeScript. 
 
 ## [2.0.0] - 2019-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  ## [2.0.1] - 2019-02-15
 
-This minor release locks the versions of `grpc-tools` and `grpc_tools_node_protoc_ts` dependencies. This allows client projects to be able to deterministicly genereate compatible protocol buffers with this project's TypeScript. 
+This patch release locks the versions of `grpc-tools` and `grpc_tools_node_protoc_ts` dependencies. This allows client projects to be able to deterministicly genereate compatible protocol buffers with this project's TypeScript. 
 
 ## [2.0.0] - 2019-02-15
 


### PR DESCRIPTION
## High Level Overview of Change

Updates changelog for 2.0.1. 

### Context of Change

The PR cut version 2.0.1: https://github.com/xpring-eng/xpring-common-js/pull/138. The PR did not update the change log, which it should have. 

### Type of Change

documentation

## Before / After

n/a

## Test Plan

n/a
<!--
## Future Tasks
For future tasks related to PR.
-->
