### PR TITLE
Remove unused method

### DIFF
--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -266,39 +266,6 @@ class Serializer {
     }
     return json
   }
-
-  /**
-   * Convert an XRPAmount to a JSON representation.
-   *
-   * @param {proto.XRPAmount} xrpAmount The XRPAmount to convert.
-   * @return {String} The XRPAmount as JSON.
-   */
-  private static legacyXRPAmountToJSON(xrpAmount: XRPAmount): string {
-    return `${xrpAmount.getDrops()}`
-  }
-
-  // TODO: Remove this function when legacyTransactionToJSON() gets removed
-  /**
-   * Change the name of a field in an object while preserving the value.
-   *
-   * @note This method has side effects to the `object` parameter.
-   *
-   * @param {String} oldPropertyName The property name to convert from.
-   * @param {String} newPropertyName The new property name.
-   * @param {Object} object The object on which the conversion is performed.
-   */
-  private static convertPropertyName(
-    /* eslint-disable @typescript-eslint/no-explicit-any */
-    oldPropertyName: string,
-    newPropertyName: string,
-    object: any,
-    /* eslint-enable @typescript-eslint/no-explicit-any */
-  ): void {
-    /* eslint-disable no-param-reassign */
-    object[newPropertyName] = object[oldPropertyName]
-    delete object[oldPropertyName]
-    /* eslint-enable no-param-reassign */
-  }
 }
 
 export default Serializer

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -266,6 +266,16 @@ class Serializer {
     }
     return json
   }
+  
+  /**	
+   * Convert an XRPAmount to a JSON representation.	
+   *	
+   * @param {proto.XRPAmount} xrpAmount The XRPAmount to convert.	
+   * @return {String} The XRPAmount as JSON.	
+   */	
+  private static legacyXRPAmountToJSON(xrpAmount: XRPAmount): string {	
+    return `${xrpAmount.getDrops()}`	
+  }
 }
 
 export default Serializer


### PR DESCRIPTION
## High Level Overview of Change

Remove `convertPropertyName`. This private method is unused. 

### Context of Change

#145 removed all usages of this private method. This PR follows up to remove this dead code.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)

## Before / After
No difference

## Test Plan

Continuous integration tests