### PR TITLE
fix XpringJS / Xpring4J

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   entry: './build/src/index.js',
   output: {
-    filename: 'index.js',
+    filename: 'bundled.js',
     libraryTarget: 'var',
     library: 'EntryPoint'
   }


### PR DESCRIPTION
## High Level Overview of Change
fixes mistake that broke XpringJS / Xpring4J (this shouldn't have been included in part 1 of the gRPC web fix)

### Context of Change
rename the output back to bundled.js

### Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

## Test Plan
Pull into XpringKit and run tests