### PR TITLE
Cut 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2019-02-24
+
+This release adds support for (protocol buffers in rippled)[https://github.com/ripple/rippled/tree/develop/src/ripple/proto/rpc/v1]. The `Signer`'s `signTransactionMethod` previously returned only the signed bytes. After this change, it returns the entire signed and encoded transaction. This encapsulates the serialization and signing logic inside of this library, rather than forcing clients to understand it. This is a breaking change (See 'Breaking Changes') below. 
+
+This release also changes the protocol buffer compiler used to generate protocol buffers in order to make this library function inside of a browser environment. As part of this change, various optimizations to TypeScript and webpack compilation are also produced (see 'Breaking Changes') below. 
+
 ### Breaking Changes
 - Modify `Signer`'s `signTransaction` method to return an array of signed bytes rather than a string based signature.
-- Changed webpack EntryPoint to XpringCommonJS
-- Changed webpack output file from bundled.js to index.js
+- Changed webpack EntryPoint to XpringCommonJS.
+- Changed webpack output file from bundled.js to index.js.
 
 ### Added
 - Added compatability for the library to be usable on the web and Node.js without having two separate codebases or build strategies by switching to using gRPC-Web instead of the Node.js version of gRPC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.0] - 2019-02-24
 
-This release adds support for (protocol buffers in rippled)[https://github.com/ripple/rippled/tree/develop/src/ripple/proto/rpc/v1]. The `Signer`'s `signTransactionMethod` previously returned only the signed bytes. After this change, it returns the entire signed and encoded transaction. This encapsulates the serialization and signing logic inside of this library, rather than forcing clients to understand it. This is a breaking change (See 'Breaking Changes') below. 
+This release adds support for (protocol buffers in rippled)[https://github.com/ripple/rippled/tree/develop/src/ripple/proto/rpc/v1]. The `Signer`'s `signTransaction` method previously returned a hex string representing the signature of the transaction. After this change, it returns the entire signed and encoded transaction as a byte array. This encapsulates the serialization and signing logic inside of this library, rather than forcing clients to understand it. This is a breaking change (See 'Breaking Changes') below. 
 
 This release also changes the protocol buffer compiler used to generate protocol buffers in order to make this library function inside of a browser environment. As part of this change, various optimizations to TypeScript and webpack compilation are also produced (see 'Breaking Changes') below. 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Common JavaScript for use within the Xpring Platform",
   "main": "build/index.js",
   "repository": "https://github.com/xpring-eng/xpring-common-js.git",


### PR DESCRIPTION
## High Level Overview of Change

Cut version 3.0.0.

### Context of Change

Version 3.0.0. contains fixes for two things we'd like to do upstream:
- signing code for rippled's protocol buffers
- webpacking gRPC

This change lets us consume this code from Xpring-JS.

Will `git tag` the master branch when this is merged. 

### Type of Change

- [x] Version release

## Before / After

N/A
## Test Plan

N/A