### PR TITLE
Export both Transaction Protocol Buffers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ export { SubmitSignedTransactionResponse } from './generated/legacy/submit_signe
 export { XRPAmount } from './generated/legacy/xrp_amount_pb'
 export { SignedTransaction } from './generated/legacy/signed_transaction_pb'
 export { TransactionStatus } from './generated/legacy/transaction_status_pb'
-export { Transaction } from './generated/legacy/transaction_pb'
+export { Transaction as LegacyTransaction } from './generated/legacy/transaction_pb'
+export { Transaction } from './generated/rpc/v1/transaction_pb'
 
 export { default as Wallet } from './wallet'
 export { default as Utils } from './utils'


### PR DESCRIPTION
## High Level Overview of Change

Export the LegacyTransaction and Transaction class so that upstream libraries can consume them.

### Context of Change

This change enables migration to rippled protocol buffers. Since these classes are used  as inputs to the `Signer` class, they need to be exported so that client classes can use them. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After
N/A

## Test Plan

N/A
<!--
## Future Tasks
For future tasks related to PR.
-->
