### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
 * @keefertaylor
+
+package-lock.json @xpring-eng/devx-reviewers


### PR DESCRIPTION
## High Level Overview of Change

Add Xpring-Eng/devx-reviewers as owners for package-lock. This lets us automatically get assignees for dependabot reviews. 
