### PR TITLE
Update ripple-keypairs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -937,14 +937,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
     },
-    "babel-runtime": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
-      "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
-      "requires": {
-        "core-js": "^1.0.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -1079,9 +1071,9 @@
       "dev": true
     },
     "bn.js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-3.3.0.tgz",
-      "integrity": "sha1-ETjld4if3Je72rUYRPIZDfwK49c="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
+      "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1764,11 +1756,6 @@
           }
         }
       }
-    },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6877,16 +6864,15 @@
       }
     },
     "ripple-keypairs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-0.11.1.tgz",
-      "integrity": "sha512-xdakxb+/4yo3TWA2ZImEma3g9OZrvoVRMDC9A2dfk6V+tBsDWug1p53bfmSnfTaue7kf2O5ejq2bfmYG8W08FA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-1.0.0.tgz",
+      "integrity": "sha512-MQ3d6fU3D+Cqu5ma4dfkfa+KakN2sKpVVVN0FeJyAYPVIGXu8Rcvd1g028TdwYAZcSYk0tGn5UhHxd0gUG3T8g==",
       "requires": {
-        "babel-runtime": "^5.8.20",
-        "bn.js": "^3.1.1",
+        "bn.js": "^5.1.1",
         "brorand": "^1.0.5",
         "elliptic": "^6.5.2",
         "hash.js": "^1.0.3",
-        "ripple-address-codec": "^2.0.1"
+        "ripple-address-codec": "^4.0.0"
       },
       "dependencies": {
         "elliptic": {
@@ -6908,15 +6894,6 @@
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
               "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
             }
-          }
-        },
-        "ripple-address-codec": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-2.0.1.tgz",
-          "integrity": "sha1-7dvjp5YNLgLFwcdPuan6DS37ZXE=",
-          "requires": {
-            "hash.js": "^1.0.3",
-            "x-address-codec": "^0.7.0"
           }
         }
       }
@@ -8391,21 +8368,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "x-address-codec": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/x-address-codec/-/x-address-codec-0.7.2.tgz",
-      "integrity": "sha1-Ki97sAJ4UgvRNzOnlZoFRD1oAuA=",
-      "requires": {
-        "base-x": "^1.0.1"
-      },
-      "dependencies": {
-        "base-x": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/base-x/-/base-x-1.1.0.tgz",
-          "integrity": "sha1-QtPXF0dPnqAiB/bRqh9CaRPut6w="
-        }
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "grpc-web": "1.0.7",
     "ripple-address-codec": "4.1.0",
     "ripple-binary-codec": "0.2.6",
-    "ripple-keypairs": "^0.11.0"
+    "ripple-keypairs": "^1.0.0"
   },
   "scripts": {
     "build": "npm run clean && ./scripts/regenerate_protos.sh && npm run lint && tsc -d && copyfiles -u 2 './src/generated/**/*' ./build/generated",

--- a/src/types/ripple-keypairs/index.d.ts
+++ b/src/types/ripple-keypairs/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'ripple-keypairs'


### PR DESCRIPTION
## High Level Overview of Change

`ripple-keypairs` hit `1.0.0`, so this library should use that over the pre-1.0 version.

### Context of Change

The reason I wrote a PR instead of just using the dependabot PR is so I could rip out the `types/ripple-keypairs/index.d.ts` file, and so we could pull in the official typings now shipped with `ripple-keypairs`.

I also verified there were no TypeScript errors as a result of having official typings. We were already compatible, which is a good sign.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Refactor (non-breaking change that only restructures code)

## Before / After

Literally removed `.d.ts` file and updated the version in `package.json`.

## Test Plan

Ran tests locally, I assume CI will also pass.

<!--
## Future Tasks
For future tasks related to PR.
-->
