### PR TITLE
Direct JS lib link & inform about Git submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,24 @@ Developers probably want to use one of the language specific libraries for [Xpri
 
 ## Getting started
 
-This library requires the Git submodules to be initialized and updated. After cloning this repository, run:
+This library requires the Git submodules to be initialized and updated, and the `protoc-gen-grpc-web` tool to be installed. After cloning this repository, run:
 
 ```
 git submodule update --init
 ```
+
+You can download the `protoc-gen-grpc-web` protoc plugin from our Github
+[release](https://github.com/grpc/grpc-web/releases) page. Make sure they are both executable and are discoverable from your PATH.
+
+For example, in MacOS, you can do:
+
+```
+sudo mv ~/Downloads/protoc-gen-grpc-web-1.0.7-darwin-x86_64 \
+  /usr/local/bin/protoc-gen-grpc-web
+chmod +x /usr/local/bin/protoc-gen-grpc-web
+```
+
+(Information from the [grpc-web](https://github.com/grpc/grpc-web/tree/master/packages/grpc-web) repository)
 
 ## Overview
 Xpring Common JavaScript is composed of several classes:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,17 @@
 
 # Xpring Common JavaScript
 
-Xpring Common JavaScript Library provides common JavaScript functionality to all client side libraries in [Xpring SDK](https://github.com/xpring-eng/xpring-sdk). This library is built to be consumed as a dependency to other libraries, rather than a standalone library.
+Xpring Common JavaScript Library provides common JavaScript functionality to all client side libraries in [Xpring SDK](https://github.com/xpring-eng/xpring-sdk) ([TS/JS version](https://github.com/xpring-eng/xpring-js)). This library is built to be consumed as a dependency to other libraries, rather than a standalone library.
 
-Developers probably want to use one of the language specific libraries for [Xpring SDK](https://github.com/xpring-eng/xpring-sdk#client-side-libraries), rather than consuming this library directly. However, developers with specific requirements for interacting with Xpring SDK may want to depend on this library.
+Developers probably want to use one of the language specific libraries for [Xpring SDK](https://github.com/xpring-eng/xpring-sdk#client-side-libraries) ([TS/JS version](https://github.com/xpring-eng/xpring-js)), rather than consuming this library directly. However, developers with specific requirements for interacting with Xpring SDK may want to depend on this library.
+
+## Getting started
+
+This library requires the Git submodules to be initialized and updated. After cloning this repository, run:
+
+```
+git submodule update --init
+```
 
 ## Overview
 Xpring Common JavaScript is composed of several classes:

--- a/README.md
+++ b/README.md
@@ -9,24 +9,7 @@ Developers probably want to use one of the language specific libraries for [Xpri
 
 ## Getting started
 
-This library requires the Git submodules to be initialized and updated, and the `protoc-gen-grpc-web` tool to be installed. After cloning this repository, run:
-
-```
-git submodule update --init
-```
-
-You can download the `protoc-gen-grpc-web` protoc plugin from our Github
-[release](https://github.com/grpc/grpc-web/releases) page. Make sure they are both executable and are discoverable from your PATH.
-
-For example, in MacOS, you can do:
-
-```
-sudo mv ~/Downloads/protoc-gen-grpc-web-1.0.7-darwin-x86_64 \
-  /usr/local/bin/protoc-gen-grpc-web
-chmod +x /usr/local/bin/protoc-gen-grpc-web
-```
-
-(Information from the [grpc-web](https://github.com/grpc/grpc-web/tree/master/packages/grpc-web) repository)
+This library requires the Git submodules to be initialized and updated and depends on protobuf and gRPC-web. More about this in the ["Building The Library"](https://github.com/xpring-eng/xpring-common-js/blob/master/CONTRIBUTING.md#building-the-library) section.
 
 ## Overview
 Xpring Common JavaScript is composed of several classes:


### PR DESCRIPTION
## High Level Overview of Change

Update Readme to contain links to the JS SDK as well (since someone using this JS lib will probably prefer to see the JS parent lib, instead of an overview with SDK's for other languages.

And: add a note about having to init and update Git submodules first, as other `npm run test` (and all other commands) will fail anyway.

### Context of Change

Dev clones, runs build/test/... » fails. Checks individual commands, checks the .sh and notices missing directories. Then checks the directories and finds out it requires a submodule.
