### PR TITLE
Upgrade rippled protos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+Update to the latest version of protocol buffers from rippled, introduced in [#3254](https://github.com/ripple/rippled/pull/3254).
+
 ## [3.0.2] - 2019-02-28
 
 ### Fixed

--- a/scripts/regenerate_protos.sh
+++ b/scripts/regenerate_protos.sh
@@ -12,6 +12,7 @@ echo "Regenerating Protocol Buffers from Rippled"
 OUT_DIR="./src/generated"
 
 PROTO_PATH="./rippled/src/ripple/proto/"
+PROTO_SRC_FILES=$PROTO_PATH/org/xrpl/rpc/v1/*.proto
 
 mkdir -p $OUT_DIR
 
@@ -20,7 +21,7 @@ $PWD/node_modules/grpc-tools/bin/protoc \
     --js_out=import_style=commonjs,binary:$OUT_DIR \
     --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:$OUT_DIR \
     --proto_path $PROTO_PATH \
-    ./rippled/src/ripple/proto/rpc/v1/*.proto
+    $PROTO_SRC_FILES
 
 ##########################################################################
 # Regenerate legacy protocol buffers.

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export { XRPAmount } from './generated/legacy/xrp_amount_pb'
 export { SignedTransaction } from './generated/legacy/signed_transaction_pb'
 export { TransactionStatus } from './generated/legacy/transaction_status_pb'
 export { Transaction as LegacyTransaction } from './generated/legacy/transaction_pb'
-export { Transaction } from './generated/rpc/v1/transaction_pb'
+export { Transaction } from './generated/org/xrpl/rpc/v1/transaction_pb'
 
 export { default as Wallet } from './wallet'
 export { default as Utils } from './utils'

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -48,17 +48,21 @@ class Serializer {
     }
 
     const sequence = transaction.getSequence()?.getValue()
+    if (sequence) {
+      object.Sequence = sequence
+    }
+
     const signingPubKeyBytes = transaction
       .getSigningPublicKey()
       ?.getValue_asU8()
-    const lastLedgerSequence = transaction.getLastLedgerSequence()?.getValue()
-    if (!sequence || !signingPubKeyBytes || !lastLedgerSequence) {
-      return
+    if (signingPubKeyBytes) {
+      object.SigningPubKey = Utils.toHex(signingPubKeyBytes)
     }
 
-    object.Sequence = sequence
-    object.SigningPubKey = Utils.toHex(signingPubKeyBytes)
-    object.LastLedgerSequence = lastLedgerSequence
+    const lastLedgerSequence = transaction.getLastLedgerSequence()?.getValue()
+    if (lastLedgerSequence) {
+      object.LastLedgerSequence = lastLedgerSequence
+    }
 
     // Convert account field, handling X-Addresses if needed.
     const accountAddress = transaction.getAccount()

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -2,7 +2,7 @@ import * as rippleCodec from 'ripple-binary-codec'
 import Serializer from './serializer'
 import { SignedTransaction } from './generated/legacy/signed_transaction_pb'
 import { Transaction as LegacyTransaction } from './generated/legacy/transaction_pb'
-import { Transaction } from './generated/rpc/v1/transaction_pb'
+import { Transaction } from './generated/org/xrpl/rpc/v1/transaction_pb'
 import Wallet from './wallet'
 import Utils from './utils'
 

--- a/test/serializer-test.ts
+++ b/test/serializer-test.ts
@@ -87,7 +87,7 @@ function makeTransaction(
   lastLedgerSequence.setValue(lastLedgerSequenceNumber)
 
   const signingPublicKey = new SigningPublicKey()
-  signingPublicKey.setValue(publicKey)
+  signingPublicKey.setValue(Utils.toBytes(publicKey))
 
   const transaction = new Transaction()
   transaction.setFee(transactionFee)

--- a/test/serializer-test.ts
+++ b/test/serializer-test.ts
@@ -2,16 +2,25 @@ import { assert } from 'chai'
 import { Payment as LegacyPayment } from '../src/generated/legacy/payment_pb'
 import Serializer from '../src/serializer'
 import { Transaction as LegacyTransaction } from '../src/generated/legacy/transaction_pb'
+import { AccountAddress } from '../src/generated/org/xrpl/rpc/v1/account_pb'
 import {
-  AccountAddress,
   CurrencyAmount,
   XRPDropsAmount,
-} from '../src/generated/rpc/v1/amount_pb'
-import { Payment, Transaction } from '../src/generated/rpc/v1/transaction_pb'
-
+} from '../src/generated/org/xrpl/rpc/v1/amount_pb'
+import {
+  Payment,
+  Transaction,
+} from '../src/generated/org/xrpl/rpc/v1/transaction_pb'
 import { XRPAmount } from '../src/generated/legacy/xrp_amount_pb'
 import 'mocha'
 import Utils from '../src/utils'
+import {
+  Destination,
+  Amount,
+  Sequence,
+  SigningPublicKey,
+  Account,
+} from '../src/generated/org/xrpl/rpc/v1/common_pb'
 
 /** Constants for transactions */
 const value = '1000'
@@ -41,12 +50,12 @@ const accountXAddress = 'X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4'
  * @param publicKey The public key of the sending account, encoded as a hexadecimal string.
  */
 function makeTransaction(
-  value: number,
-  destination: string,
-  fee: number,
-  lastLedgerSequence: number,
-  sequence: number,
-  account: string | undefined,
+  value: string,
+  destinationAddress: string,
+  fee: string,
+  lastLedgerSequenceNumber: number,
+  sequenceNumber: number,
+  senderAddress: string | undefined,
   publicKey: string,
 ): Transaction {
   const paymentAmount = new XRPDropsAmount()
@@ -55,28 +64,47 @@ function makeTransaction(
   const currencyAmount = new CurrencyAmount()
   currencyAmount.setXrpAmount(paymentAmount)
 
-  const destinationAddress = new AccountAddress()
-  destinationAddress.setAddress(destination)
+  const amount = new Amount()
+  amount.setValue(currencyAmount)
+
+  const destinationAccountAddress = new AccountAddress()
+  destinationAccountAddress.setAddress(destinationAddress)
+
+  const destination = new Destination()
+  destination.setValue(destinationAccountAddress)
 
   const payment = new Payment()
-  payment.setDestination(destinationAddress)
-  payment.setAmount(currencyAmount)
+  payment.setDestination(destination)
+  payment.setAmount(amount)
 
   const transactionFee = new XRPDropsAmount()
   transactionFee.setDrops(fee)
+
+  const sequence = new Sequence()
+  sequence.setValue(sequenceNumber)
+
+  const lastLedgerSequence = new Sequence()
+  lastLedgerSequence.setValue(lastLedgerSequenceNumber)
+
+  const signingPublicKey = new SigningPublicKey()
+  signingPublicKey.setValue(publicKey)
 
   const transaction = new Transaction()
   transaction.setFee(transactionFee)
   transaction.setSequence(sequence)
   transaction.setPayment(payment)
-  transaction.setSigningPublicKey(Utils.toBytes(publicKey))
+  transaction.setSigningPublicKey(signingPublicKey)
   transaction.setLastLedgerSequence(lastLedgerSequence)
 
   // Account is an optional input so that malformed transaction serialization can be tested.
-  if (account) {
-    const sender = new AccountAddress()
-    sender.setAddress(account)
-    transaction.setAccount(sender)
+  if (senderAddress) {
+    const senderAccountAddress = new AccountAddress()
+    senderAccountAddress.setAddress(senderAddress)
+
+    const senderAccount = new Account()
+    senderAccount.setValue(senderAccountAddress)
+
+    transaction.setAccount(senderAccount)
   }
 
   return transaction
@@ -287,9 +315,9 @@ describe('serializer', function(): void {
   it('serializes a payment in XRP from a classic address', function(): void {
     // GIVEN a transaction which represents a payment denominated in XRP.
     const transaction = makeTransaction(
-      Number(value),
+      value,
       destinationClassicAddress,
-      Number(fee),
+      fee,
       lastLedgerSequence,
       sequence,
       accountClassicAddress,
@@ -316,9 +344,9 @@ describe('serializer', function(): void {
   it('serializes a payment in XRP from an X-Address with no tag', function(): void {
     // GIVEN a transaction which represents a payment denominated in XRP.
     const transaction = makeTransaction(
-      Number(value),
+      value,
       destinationClassicAddress,
-      Number(fee),
+      fee,
       lastLedgerSequence,
       sequence,
       accountXAddress,
@@ -346,9 +374,9 @@ describe('serializer', function(): void {
     // GIVEN a transaction which represents a payment denominated in XRP from a sender with a tag.
     const account = Utils.encodeXAddress(accountClassicAddress, tag)
     const transaction = makeTransaction(
-      Number(value),
+      value,
       destinationClassicAddress,
-      Number(fee),
+      fee,
       lastLedgerSequence,
       sequence,
       account,
@@ -365,9 +393,9 @@ describe('serializer', function(): void {
   it('fails to serializes a payment in XRP when account is undefined', function(): void {
     // GIVEN a transaction which represents a payment denominated in XRP.
     const transaction = makeTransaction(
-      Number(value),
+      value,
       destinationClassicAddress,
-      Number(fee),
+      fee,
       lastLedgerSequence,
       sequence,
       undefined,
@@ -384,9 +412,9 @@ describe('serializer', function(): void {
   it('serializes a payment to an X-address with a tag in XRP', function(): void {
     // GIVEN a transaction which represents a payment to a destination and tag, denominated in XRP.
     const transaction = makeTransaction(
-      Number(value),
+      value,
       destinationXAddressWithTag,
-      Number(fee),
+      fee,
       lastLedgerSequence,
       sequence,
       accountClassicAddress,
@@ -414,9 +442,9 @@ describe('serializer', function(): void {
   it('serializes a payment to an X-address without a tag in XRP', function(): void {
     // GIVEN a transaction which represents a payment to a destination without a tag, denominated in XRP.
     const transaction = makeTransaction(
-      Number(value),
+      value,
       destinationXAddressWithoutTag,
-      Number(fee),
+      fee,
       lastLedgerSequence,
       sequence,
       accountClassicAddress,

--- a/test/signer-test.ts
+++ b/test/signer-test.ts
@@ -123,6 +123,7 @@ describe('signer', function(): void {
       transaction,
       fakeSignature,
     )
+
     const expectedSignedTransactionHex = rippleCodec.encode(
       expectedSignedTransactionJSON,
     )

--- a/test/signer-test.ts
+++ b/test/signer-test.ts
@@ -7,13 +7,22 @@ import { Transaction as LegacyTransaction } from '../src/generated/legacy/transa
 import { XRPAmount } from '../src/generated/legacy/xrp_amount_pb'
 import 'mocha'
 import {
-  AccountAddress,
   CurrencyAmount,
   XRPDropsAmount,
-} from '../src/generated/rpc/v1/amount_pb'
-import { Payment, Transaction } from '../src/generated/rpc/v1/transaction_pb'
+} from '../src/generated/org/xrpl/rpc/v1/amount_pb'
+import {
+  Payment,
+  Transaction,
+} from '../src/generated/org/xrpl/rpc/v1/transaction_pb'
+import { AccountAddress } from '../src/generated/org/xrpl/rpc/v1/account_pb'
 import Utils from '../src/utils'
 import Serializer from '../src/serializer'
+import {
+  Destination,
+  Sequence,
+  Account,
+  Amount,
+} from '../src/generated/org/xrpl/rpc/v1/common_pb'
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
@@ -66,10 +75,10 @@ describe('signer', function(): void {
     const fakeSignature = 'DEADBEEF'
     const wallet = new FakeWallet(fakeSignature)
 
-    const value = 1000
-    const destination = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
-    const fee = 10
-    const sequence = 1
+    const value = '1000'
+    const destinationAddress = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
+    const fee = '10'
+    const sequenceNumber = 1
     const account = 'X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4'
 
     const paymentAmount = new XRPDropsAmount()
@@ -78,18 +87,30 @@ describe('signer', function(): void {
     const currencyAmount = new CurrencyAmount()
     currencyAmount.setXrpAmount(paymentAmount)
 
-    const destinationAddress = new AccountAddress()
-    destinationAddress.setAddress(destination)
+    const destinationAccountAddress = new AccountAddress()
+    destinationAccountAddress.setAddress(destinationAddress)
+
+    const destination = new Destination()
+    destination.setValue(destinationAccountAddress)
+
+    const amount = new Amount()
+    amount.setValue(currencyAmount)
 
     const payment = new Payment()
-    payment.setDestination(destinationAddress)
-    payment.setAmount(currencyAmount)
+    payment.setDestination(destination)
+    payment.setAmount(amount)
 
     const transactionFee = new XRPDropsAmount()
     transactionFee.setDrops(fee)
 
-    const sender = new AccountAddress()
-    sender.setAddress(account)
+    const senderAccountAddress = new AccountAddress()
+    senderAccountAddress.setAddress(account)
+
+    const sender = new Account()
+    sender.setValue(senderAccountAddress)
+
+    const sequence = new Sequence()
+    sequence.setValue(sequenceNumber)
 
     const transaction = new Transaction()
     transaction.setAccount(sender)


### PR DESCRIPTION
## High Level Overview of Change

Upgrade xpring-common-js to consume the latest protocol buffers in rippled, which contain breaking changes introduced in https://github.com/ripple/rippled/pull/3254. 

### Context of Change

No logic changes are introduced. 

Changes in the protocol buffers are:
- Change folder / package location of files
- Use numeric strings instead of numbers to prevent overflows when working with 64 bit integers. 
- Introduce new layers of abstraction internally. 

### Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Before / After

Clients who use new versions of protocol buffers can now use the latest versions. 

## Test Plan
CI