### PR TITLE
[PayID] Add `PayIDUtil` and `PaymentPointer` 

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -8,6 +8,7 @@ module.exports = {
   extension: [
     'ts'
   ],
+  spec: "test/**/*-test.ts",
   
   // Do not look for mocha opts file
   opts: false,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `PaymentPointer`: A new model object to work with conceptual components of payment pointers. See: https://paymentpointers.org/syntax-resolution/
+- `PayIDUtils`: A static utility class for working with PayID constructs.
+
 ## [4.0.0] - 2020-02-28
 
 This version uses new protocol buffers from rippled which have breaking changes in them. Specifically, the breaking changes include:

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -13,20 +13,37 @@ export default class PayIDUtils {
   public static parsePaymentPointer(
     paymentPointer: string,
   ): PaymentPointer | undefined {
-    // Payment pointers must start with a '$'
-    if (!paymentPointer.startsWith('$')) {
-      return
-    }
+    // Input must be ascii only.
+    if (PayIDUtils.isASCII(paymentPointer)) return
+
+    // Payment pointers must start with a '$'.
+    if (!paymentPointer.startsWith('$')) return
 
     const address = paymentPointer.substring(1)
     const pathIndex = address.indexOf('/')
+
+    // Host must not be empty.
+    const host = pathIndex >= 0 ? address.substring(0, pathIndex) : address
+    if (host === '') return
+
     if (pathIndex >= 0) {
-      return new PaymentPointer(
-        address.substring(0, pathIndex),
-        address.substring(pathIndex),
-      )
+      return new PaymentPointer(host, address.substring(pathIndex))
     }
-    return new PaymentPointer(address)
+    return new PaymentPointer(host)
+  }
+
+  /**
+   * Validate if the input is ASCII based text.
+   *
+   * Shamelessly taken from:
+   * https://stackoverflow.com/questions/14313183/javascript-regex-how-do-i-check-if-the-string-is-ascii-only
+   *
+   * @param input The input to check
+   * @returns A boolean indicating the result.
+   */
+  private static isASCII(input: string): boolean {
+    // eslint-disable-next-line no-control-regex
+    return /^[\x00-\x7F]*$/.test(input)
   }
 
   /** Please do not instantiate this static utility class. */

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -1,0 +1,35 @@
+import PaymentPointer from './payment-pointer'
+
+/**
+ * A static utility class for PayID.
+ */
+export default class PayIDUtils {
+  /**
+   * Parse a payment pointer string to a payment pointer object
+   *
+   * @param paymentPointer The input string payment pointer.
+   * @returns A PaymentPointer object if the input was valid, otherwise undefined.
+   */
+  public static parsePaymentPointer(
+    paymentPointer: string,
+  ): PaymentPointer | undefined {
+    // Payment pointers must start with a '$'
+    if (!paymentPointer.startsWith('$')) {
+      return
+    }
+
+    const address = paymentPointer.substring(1)
+    const pathIndex = address.indexOf('/')
+    if (pathIndex >= 0) {
+      return new PaymentPointer(
+        address.substring(0, pathIndex),
+        address.substring(pathIndex),
+      )
+    }
+    return new PaymentPointer(address)
+  }
+
+  /** Please do not instantiate this static utility class. */
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private constructor() {}
+}

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -14,6 +14,8 @@ export default class PayIDUtils {
     paymentPointer: string,
   ): PaymentPointer | undefined {
     // Input must be ascii only.
+    // TODO(keefertaylor): Reconcile whether this is a needed constraint.
+    // See: https://app.asana.com/0/1143722888069470/1165014342225697
     if (!PayIDUtils.isASCII(paymentPointer)) return
 
     // Payment pointers must start with a '$'.

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -14,7 +14,7 @@ export default class PayIDUtils {
     paymentPointer: string,
   ): PaymentPointer | undefined {
     // Input must be ascii only.
-    if (PayIDUtils.isASCII(paymentPointer)) return
+    if (!PayIDUtils.isASCII(paymentPointer)) return
 
     // Payment pointers must start with a '$'.
     if (!paymentPointer.startsWith('$')) return

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -14,8 +14,6 @@ export default class PayIDUtils {
     paymentPointer: string,
   ): PaymentPointer | undefined {
     // Input must be ascii only.
-    // TODO(keefertaylor): Reconcile whether this is a needed constraint.
-    // See: https://app.asana.com/0/1143722888069470/1165014342225697
     if (!PayIDUtils.isASCII(paymentPointer)) return
 
     // Payment pointers must start with a '$'.

--- a/src/PayID/payment-pointer.ts
+++ b/src/PayID/payment-pointer.ts
@@ -27,6 +27,6 @@ export default class PaymentPointer {
     // An empty path of '/' path defaults to a WELL_KNOWN path.
     const normalizedPath = path || PaymentPointer.WELL_KNOWN_PATH
     this.path =
-      normalizedPath === '/' ? normalizedPath : PaymentPointer.WELL_KNOWN_PATH
+      normalizedPath === '/' ? PaymentPointer.WELL_KNOWN_PATH : normalizedPath
   }
 }

--- a/src/PayID/payment-pointer.ts
+++ b/src/PayID/payment-pointer.ts
@@ -1,0 +1,32 @@
+/**
+ * A class which which encapsulates components of a Payment Pointer.
+ *
+ * See: https://paymentpointers.org/syntax-resolution/
+ */
+export default class PaymentPointer {
+  /** The well known path. */
+  public static WELL_KNOWN_PATH = '/.well-known/pay'
+
+  /** The host of the payment pointer. */
+  public readonly host: string
+
+  /** The path of the payment pointer. */
+  public readonly path: string
+
+  /**
+   * Create a new PaymentPointer.
+   *
+   * If the path is given as undefined or `/` the well known path is created.
+   *
+   * @param host The host of the payment pointer.
+   * @param path The path of the payment pointer.
+   */
+  public constructor(host: string, path?: string | undefined) {
+    this.host = host
+
+    // An empty path of '/' path defaults to a WELL_KNOWN path.
+    const normalizedPath = path || PaymentPointer.WELL_KNOWN_PATH
+    this.path =
+      normalizedPath === '/' ? normalizedPath : PaymentPointer.WELL_KNOWN_PATH
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,9 @@ export { default as Utils } from './utils'
 export { default as Signer } from './signer'
 export { default as Serializer } from './serializer'
 
+export { default as PayIDUtils } from './PayID/pay-id-utils'
+export { default as PaymentPointer } from './PayID/payment-pointer'
+
 // Type Exports
 export { WalletGenerationResult } from './wallet'
 export { ClassicAddress } from './utils'

--- a/test/PayID/pay-id-utils-test.ts
+++ b/test/PayID/pay-id-utils-test.ts
@@ -12,8 +12,8 @@ describe('PayIDUtils', function(): void {
     const paymentPointer = PayIDUtils.parsePaymentPointer(rawPaymentPointer)
 
     // THEN the host and path are set correctly.
-    assert.equal(paymentPointer.host, 'example.com')
-    assert.equal(paymentPointer.path, '/foo')
+    assert.equal(paymentPointer?.host, 'example.com')
+    assert.equal(paymentPointer?.path, '/foo')
   })
 
   it('parse payment pointer - well known path', function(): void {
@@ -24,8 +24,8 @@ describe('PayIDUtils', function(): void {
     const paymentPointer = PayIDUtils.parsePaymentPointer(rawPaymentPointer)
 
     // THEN the host and path are set correctly.
-    assert.equal(paymentPointer.host, 'example.com')
-    assert.equal(paymentPointer.path, PaymentPointer.WELL_KNOWN_PATH)
+    assert.equal(paymentPointer?.host, 'example.com')
+    assert.equal(paymentPointer?.path, PaymentPointer.WELL_KNOWN_PATH)
   })
 
   it('parse payment pointer - well known path trailing slash', function(): void {
@@ -36,8 +36,8 @@ describe('PayIDUtils', function(): void {
     const paymentPointer = PayIDUtils.parsePaymentPointer(rawPaymentPointer)
 
     // THEN the host and path are set correctly.
-    assert.equal(paymentPointer.host, 'example.com')
-    assert.equal(paymentPointer.path, PaymentPointer.WELL_KNOWN_PATH)
+    assert.equal(paymentPointer?.host, 'example.com')
+    assert.equal(paymentPointer?.path, PaymentPointer.WELL_KNOWN_PATH)
   })
 
   it('parse payment pointer - incorrect prefix', function(): void {

--- a/test/PayID/pay-id-utils-test.ts
+++ b/test/PayID/pay-id-utils-test.ts
@@ -1,0 +1,66 @@
+import { assert } from 'chai'
+import PayIDUtils from '../../src/PayID/pay-id-utils'
+import 'mocha'
+import PaymentPointer from '../../src/PayID/payment-pointer'
+
+describe('PayIDUtils', function(): void {
+  it('parse payment pointer - host and path', function(): void {
+    // GIVEN a payment pointer with a host and a path.
+    const rawPaymentPointer = '$example.com/foo'
+
+    // WHEN it is parsed to a PaymentPointer object
+    const paymentPointer = PayIDUtils.parsePaymentPointer(rawPaymentPointer)
+
+    // THEN the host and path are set correctly.
+    assert.equal(paymentPointer.host, 'example.com')
+    assert.equal(paymentPointer.path, '/foo')
+  })
+
+  it('parse payment pointer - well known path', function(): void {
+    // GIVEN a payment pointer with a well known path.
+    const rawPaymentPointer = '$example.com'
+
+    // WHEN it is parsed to a PaymentPointer object
+    const paymentPointer = PayIDUtils.parsePaymentPointer(rawPaymentPointer)
+
+    // THEN the host and path are set correctly.
+    assert.equal(paymentPointer.host, 'example.com')
+    assert.equal(paymentPointer.path, PaymentPointer.WELL_KNOWN_PATH)
+  })
+
+  it('parse payment pointer - well known path trailing slash', function(): void {
+    // GIVEN a payment pointer with a well known path and a trailing slash.
+    const rawPaymentPointer = '$example.com/'
+
+    // WHEN it is parsed to a PaymentPointer object
+    const paymentPointer = PayIDUtils.parsePaymentPointer(rawPaymentPointer)
+
+    // THEN the host and path are set correctly.
+    assert.equal(paymentPointer.host, 'example.com')
+    assert.equal(paymentPointer.path, PaymentPointer.WELL_KNOWN_PATH)
+  })
+
+  it('parse payment pointer - incorrect prefix', function(): void {
+    // GIVEN a payment pointer without a '$' prefix
+    const rawPaymentPointer = 'example.com/'
+
+    // WHEN it is parsed to a PaymentPointer object THEN the result is undefined
+    assert.isUndefined(PayIDUtils.parsePaymentPointer(rawPaymentPointer))
+  })
+
+  it('parse payment pointer - empty host', function(): void {
+    // GIVEN a payment pointer without a host.
+    const rawPaymentPointer = '$'
+
+    // WHEN it is parsed to a PaymentPointer object THEN the result is undefined
+    assert.isUndefined(PayIDUtils.parsePaymentPointer(rawPaymentPointer))
+  })
+
+  it('parse payment pointer - non-ascii characters', function(): void {
+    // GIVEN a payment pointer with non-ascii characters.
+    const rawPaymentPointer = '$ZA̡͊͠͝LGΌ IS̯͈͕̹̘̱ͮ TO͇̹̺ͅƝ̴ȳ̳ TH̘Ë͖́̉ ͠P̯͍̭O̚N̐Y̡'
+
+    // WHEN it is parsed to a PaymentPointer object THEN the result is undefined
+    assert.isUndefined(PayIDUtils.parsePaymentPointer(rawPaymentPointer))
+  })
+})


### PR DESCRIPTION
## High Level Overview of Change

Add common PayID functionality:
- `PayIDUtil`: Static utilities for working with PayID
- `PaymentPointer`: Model object of a payment pointer

### Context of Change

This algorithm is modeled of Quilt Java code:
- Code: https://github.com/hyperledger/quilt/blob/master/spsp-parent/spsp-core/src/main/java/org/interledger/spsp/PaymentPointer.java
- Unit Tests: https://github.com/hyperledger/quilt/blob/master/spsp-parent/spsp-core/src/test/java/org/interledger/spsp/PaymentPointerTest.java

This is prep work to begin to make calls to a PayID service in higher level libraries (JS / Java / ILP). Since this code is somewhat complex I think it makes sense to place it into the common core to begin with and bind it upwards.

Based on the flux level of PayID / SDK features in general, I'm going to defer writing technical documentation for this at the moment. I think we'll do a single pass ahead of our next launch. I have updated CHANGELOG.md.

Payment pointers are generic across ILP / PayID so this will probably eventually be refactored into a `Common` folder. 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

New class introduced. 

## Test Plan

CI