### PR TITLE
[4.2.0] Sign raw JSON transactions and cut release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.2.0] - 2020-03-16
+
+Adds the Signer.signTransactionFromJSON function.
+
 ## [4.1.0] - 2020-03-04
 
 This release adds new functionality to work with the PayID system in Xpring SDK.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Common JavaScript for use within the Xpring Platform",
   "main": "build/index.js",
   "repository": "https://github.com/xpring-eng/xpring-common-js.git",

--- a/src/serializer.ts
+++ b/src/serializer.ts
@@ -15,7 +15,7 @@ interface PaymentJSON {
   TransactionType: string
 }
 
-interface TransactionJSON {
+interface BaseTransactionJSON {
   Account: string
   Fee: string
   LastLedgerSequence: number
@@ -23,6 +23,15 @@ interface TransactionJSON {
   SigningPubKey: string
   TxnSignature?: string
 }
+
+interface PaymentTransactionJSONAddition extends PaymentJSON {
+  TransactionType: 'Payment'
+}
+
+type PaymentTransactionJSON = BaseTransactionJSON &
+  PaymentTransactionJSONAddition
+
+export type TransactionJSON = BaseTransactionJSON | PaymentTransactionJSON
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.

--- a/test/signer-test.ts
+++ b/test/signer-test.ts
@@ -150,24 +150,14 @@ describe('signer', function(): void {
       'X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4',
     )
 
-    // make mocha and typescript happy
-    if (destinationAddress == null) {
-      assert.fail('destinationAddress is undefined')
-      return
-    }
-    if (sourceAddress == null) {
-      assert.fail('sourceAddress is undefined')
-      return
-    }
-
     const transactionJSON = {
-      Account: sourceAddress.address,
+      Account: sourceAddress!.address,
       Fee: '10',
       Sequence: 1,
       LastLedgerSequence: 0,
       SigningPubKey: 'BEEFDEAD',
       Amount: '1000',
-      Destination: destinationAddress.address,
+      Destination: destinationAddress!.address,
       TransactionType: 'Payment',
     }
 

--- a/test/signer-test.ts
+++ b/test/signer-test.ts
@@ -138,4 +138,60 @@ describe('signer', function(): void {
     assert.exists(signedTransaction)
     assert.deepEqual(signedTransaction, expectedSignedTransaction)
   })
+
+  it('sign from JSON', function(): void {
+    // GIVEN an transaction and a wallet and expected signing artifacts.
+    const fakeSignature = 'DEADBEEF'
+    const wallet = new FakeWallet(fakeSignature)
+    const destinationAddress = Utils.decodeXAddress(
+      'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc',
+    )
+    const sourceAddress = Utils.decodeXAddress(
+      'X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4',
+    )
+
+    // make mocha and typescript happy
+    if (destinationAddress == null) {
+      assert.fail('destinationAddress is undefined')
+      return
+    }
+    if (sourceAddress == null) {
+      assert.fail('sourceAddress is undefined')
+      return
+    }
+
+    const transactionJSON = {
+      Account: sourceAddress.address,
+      Fee: '10',
+      Sequence: 1,
+      LastLedgerSequence: 0,
+      SigningPubKey: 'BEEFDEAD',
+      Amount: '1000',
+      Destination: destinationAddress.address,
+      TransactionType: 'Payment',
+    }
+
+    // Encode transaction with the expected signature.
+    const expectedSignedTransactionJSON = {
+      ...transactionJSON,
+      TxnSignature: fakeSignature,
+    }
+
+    const expectedSignedTransactionHex = rippleCodec.encode(
+      expectedSignedTransactionJSON,
+    )
+    const expectedSignedTransaction = Utils.toBytes(
+      expectedSignedTransactionHex,
+    )
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransactionFromJSON(
+      transactionJSON,
+      wallet,
+    )
+
+    // THEN the signing artifacts are as expected.
+    assert.exists(signedTransaction)
+    assert.deepEqual(signedTransaction, expectedSignedTransaction)
+  })
 })


### PR DESCRIPTION
## High Level Overview of Change

Added a new public function: `Signer.signTransactionFromJSON`. This allows non-JS runtimes to sign transactions without making network requests from JS or passing complex proto objects to JS. Instead, we can just pass the basic necessary JSON for signing.

Refactors `Signer.signTransaction` in terms of the above function.

(I believe) corrects the `TransactionJSON` type in `Serializer` so that it more accurately reflects the true JSON serialization of a transaction.

Adds a new test for the new `Signer` function.

NOTE: previously `Signer.signTransaction` would serialize the transaction object, then sign it, then serialize it again. **As far as I can tell** this is unnecessary so I removed it. It will now serialize the transaction object, sign it, then simply add the signature key to the already-serialized object. Would appreciate someone double-checking that!

### Context of Change

This will allow a (soon-to-be-released) Ruby Xpring library to work more easily.

### Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] Refactor (non-breaking change that only restructures code)

## Before / After

I think the above summary describes this.

## Test Plan

The automated tests still work. Added a new automated test. Verified that the generated code will do what is required for the upcoming Ruby lib.

