### PR TITLE
cut 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2020-04-08
+
+This fix release fixes build references. 
+
+## [5.0.0] - 2020-04-08
+
 ### Added
 - A new `FakeWallet` is exported from the library to assist clients in unit testing.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Common JavaScript for use within the Xpring Platform",
   "main": "build/index.js",
   "repository": "https://github.com/xpring-eng/xpring-common-js.git",


### PR DESCRIPTION
## High Level Overview of Change

Cut release 5.0.1 which contains necessary atoms for PayID. 

After merging this PR I will run:
```
$ git checkout master && git pull
$ git tag '5.0.1' && git push --tags
$ npm publish
```
