### PR TITLE
Provide Idiomatically Cased Pay ID Classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A new class `WalletFactory` encapsulates functionality for creating a `Wallet` object from a public and private key.
+
 ## [5.0.3] - 2020-04-10
 
 This fix release contains minor improvements to experimental components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A new class, `PayIdUtils`, replaces the functionality in `PayIDUtils` with an idiomatically cased name.
+- A new class, `PayIdComponents`, replaces the functionality in `PayIDComponents` with an idiomatically cased name.
+
+### Deprecated
+- `PayIDUtils` is deprecated. Please use the idiomatically cased `PayIdUtils` class instead.
+- `PayIDComponents` is deprecated. Please use the idiomatically cased `PayIdComponents` class instead.
 
 ## [5.0.3] - 2020-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- A new class `WalletFactory` encapsulates functionality for creating a `Wallet` object from a public and private key.
 
 ## [5.0.3] - 2020-04-10
 

--- a/src/PayID/pay-id-components.ts
+++ b/src/PayID/pay-id-components.ts
@@ -1,7 +1,29 @@
+// Disable multiple classes to accommodate the switch to idiomatic style naming.
+// TODO(keefertaylor): Remove this when migration is complete.
+/* eslint-disable  max-classes-per-file */
+
 /**
  * A class which encapsulates components of a Pay ID.
  */
-export default class PayIDComponents {
+export default class PayIdComponents {
+  /**
+   * Create a new PayIdComponents.
+   *
+   * @param host - The host of the payment pointer.
+   * @param path - The path of the payment pointer, starting with a leading '/'.
+   */
+  public constructor(
+    public readonly host: string,
+    public readonly path: string,
+  ) {}
+}
+
+/**
+ * A class which encapsulates components of a Pay ID.
+ *
+ * @deprecated Please use the idiomatically named `PayIdComponents` class instead.
+ */
+export class PayIDComponents {
   /**
    * Create a new PayIDComponents.
    *

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -1,17 +1,21 @@
-import PayIDComponents from './pay-id-components'
+// Disable multiple classes to accommodate the switch to idiomatic style naming.
+// TODO(keefertaylor): Remove this when migration is complete.
+/* eslint-disable  max-classes-per-file */
+
+import PayIdComponents, { PayIDComponents } from './pay-id-components'
 
 /**
- * A static utility class for PayID.
+ * A static utility class for Pay ID functionality.
  */
-export default class PayIDUtils {
+export default class PayIdUtils {
   /**
    * Parse a PayID string to a set of PayIDComponents object
    *
    * @param parsePayID - The input Pay ID.
    * @returns A PayIDComponents object if the input was valid, otherwise undefined.
    */
-  public static parsePayID(payID: string): PayIDComponents | undefined {
-    if (!PayIDUtils.isASCII(payID)) {
+  public static parsePayID(payID: string): PayIdComponents | undefined {
+    if (!PayIdUtils.isASCII(payID)) {
       return
     }
 
@@ -28,7 +32,7 @@ export default class PayIDUtils {
       return
     }
 
-    return new PayIDComponents(host, `/${path}`)
+    return new PayIdComponents(host, `/${path}`)
   }
 
   /**
@@ -43,6 +47,27 @@ export default class PayIDUtils {
   private static isASCII(input: string): boolean {
     // eslint-disable-next-line no-control-regex
     return /^[\x00-\x7F]*$/u.test(input)
+  }
+
+  /** Please do not instantiate this static utility class. */
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private constructor() {}
+}
+
+/**
+ * A static utility class for PayID.
+ *
+ * @deprecated Please use the idiomatically named `PayIdUtils` class instead.
+ */
+export class PayIDUtils {
+  /**
+   * Parse a PayID string to a set of PayIDComponents object
+   *
+   * @param parsePayID - The input Pay ID.
+   * @returns A PayIDComponents object if the input was valid, otherwise undefined.
+   */
+  public static parsePayID(payID: string): PayIDComponents | undefined {
+    return PayIdUtils.parsePayID(payID)
   }
 
   /** Please do not instantiate this static utility class. */

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -67,7 +67,10 @@ export class PayIDUtils {
    * @returns A PayIDComponents object if the input was valid, otherwise undefined.
    */
   public static parsePayID(payID: string): PayIDComponents | undefined {
-    return PayIdUtils.parsePayID(payID)
+    const components = PayIdUtils.parsePayID(payID)
+    return components !== undefined
+      ? new PayIDComponents(components?.host, components?.path)
+      : undefined
   }
 
   /** Please do not instantiate this static utility class. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,11 @@ export { default as Utils } from './Common/utils'
 export { default as Signer } from './XRP/signer'
 export { default as Serializer } from './XRP/serializer'
 
-export { default as PayIDUtils } from './PayID/pay-id-utils'
-export { default as PayIDComponents } from './PayID/pay-id-components'
+export { default as PayIdUtils, PayIDUtils } from './PayID/pay-id-utils'
+export {
+  default as PayIdComponents,
+  PayIDComponents,
+} from './PayID/pay-id-components'
 
 // Fakes for Tests
 export { default as FakeWallet } from '../test/XRP/fakes/fake-wallet'

--- a/test/PayID/pay-id-utils.test.ts
+++ b/test/PayID/pay-id-utils.test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai'
 
-import PayIDUtils from '../../src/PayID/pay-id-utils'
+import PayIdUtils from '../../src/PayID/pay-id-utils'
 import 'mocha'
 
 describe('PayIDUtils', function (): void {
@@ -11,7 +11,7 @@ describe('PayIDUtils', function (): void {
     const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIDUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
 
     // THEN the host and path are set correctly.
     assert.equal(payIDComponents?.host, host)
@@ -25,7 +25,7 @@ describe('PayIDUtils', function (): void {
     const rawPayID = `${host}$${path}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIDUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
 
     // THEN the Pay ID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -38,7 +38,7 @@ describe('PayIDUtils', function (): void {
     const rawPayID = `${host}$${path}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIDUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
 
     // THEN the Pay ID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -51,7 +51,7 @@ describe('PayIDUtils', function (): void {
     const rawPayID = `${host}$${path}`
 
     // WHEN it is parsed to components.
-    const payIDComponents = PayIDUtils.parsePayID(rawPayID)
+    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
 
     // THEN the Pay ID failed to parse.
     assert.isUndefined(payIDComponents)
@@ -62,6 +62,6 @@ describe('PayIDUtils', function (): void {
     const rawPayID = 'ZA̡͊͠͝LGΌIS̯͈͕̹̘̱ͮ$TO͇̹̺ͅƝ̴ȳ̳TH̘Ë͖́̉ ͠P̯͍̭O̚N̐Y̡'
 
     // WHEN it is parsed to components THEN the result is undefined
-    assert.isUndefined(PayIDUtils.parsePayID(rawPayID))
+    assert.isUndefined(PayIdUtils.parsePayID(rawPayID))
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

JavaScript tends to favor only casing the first letter of acronyms (PayId vs PayID). Start to re-case our classes to this style. 

### Context of Change

We use both styles of this casing across our JavaScript libraries (see `IlpClient` and `XRPClient`). JavaScript tends to favor the former case. 

This PR re-cases the Pay ID functionality to use the correct casing. Specifically:
- Duplicate each incorrectly cased class into a correctly cased class. 
- Modify the incorrectly cased class to call the correctly case classed
- Mark the incorrectly cased class as deprecated
- Update our tests immediately to the new casing
- Update `index.ts` to export both classes. 

A future PR will remove the incorrectly cased classes in N+2 releases, as described by our new release policy. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

A bridge to correctly named classes is provided. 

## Test Plan

CI

<!--
## Future Tasks
For future tasks related to PR.
-->
