### PR TITLE
Xpring eslint 2

### DIFF
--- a/src/Common/utils.ts
+++ b/src/Common/utils.ts
@@ -177,7 +177,7 @@ abstract class Utils {
     const hashHex = sha512.update(bytes).digest('hex').toUpperCase()
     const hash = this.toBytes(hashHex)
 
-    return hash.slice(0, 32)
+    return hash.slice(0, hash.length / 2)
   }
 }
 

--- a/src/Common/utils.ts
+++ b/src/Common/utils.ts
@@ -10,7 +10,8 @@ import * as addressCodec from 'ripple-address-codec'
 const signedTransactionPrefixHex = '54584E00'
 
 /**
- * A simple property bag which contains components of a classic address. Components contained in this object are neither sanitized or validated.
+ * A simple property bag which contains components of a classic address.
+ * Components contained in this object are neither sanitized or validated.
  */
 export interface ClassicAddress {
   /** A classic address. */

--- a/src/Common/utils.ts
+++ b/src/Common/utils.ts
@@ -176,7 +176,7 @@ class Utils {
    * @returns true if the input is valid hex, otherwise false.
    */
   public static isHex(input: string): boolean {
-    const hexRegEx = /([0-9]|[a-f])/gimu
+    const hexRegEx = /(?:[0-9]|[a-f])/gimu
     return (input.match(hexRegEx) ?? []).length === input.length
   }
 }

--- a/src/Common/utils.ts
+++ b/src/Common/utils.ts
@@ -24,7 +24,7 @@ export interface ClassicAddress {
   test: boolean
 }
 
-class Utils {
+abstract class Utils {
   /**
    * Validate that the given string is a valid address for the XRP Ledger.
    *
@@ -156,6 +156,17 @@ class Utils {
   }
 
   /**
+   * Check if the given string is valid hex.
+   *
+   * @param input - The input to check.
+   * @returns true if the input is valid hex, otherwise false.
+   */
+  public static isHex(input: string): boolean {
+    const hexRegEx = /(?:[0-9]|[a-f])/gimu
+    return (input.match(hexRegEx) ?? []).length === input.length
+  }
+
+  /**
    * Compute the SHA512 half hash of the given bytes.
    *
    * @param input - The input to hash.
@@ -167,17 +178,6 @@ class Utils {
     const hash = this.toBytes(hashHex)
 
     return hash.slice(0, 32)
-  }
-
-  /**
-   * Check if the given string is valid hex.
-   *
-   * @param input - The input to check.
-   * @returns true if the input is valid hex, otherwise false.
-   */
-  public static isHex(input: string): boolean {
-    const hexRegEx = /(?:[0-9]|[a-f])/gimu
-    return (input.match(hexRegEx) ?? []).length === input.length
   }
 }
 

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -3,7 +3,7 @@ import PayIDComponents from './pay-id-components'
 /**
  * A static utility class for PayID.
  */
-export default class PayIDUtils {
+export default abstract class PayIDUtils {
   /**
    * Parse a PayID string to a set of PayIDComponents object
    *
@@ -44,8 +44,4 @@ export default class PayIDUtils {
     // eslint-disable-next-line no-control-regex
     return /^[\x00-\x7F]*$/u.test(input)
   }
-
-  /** Please do not instantiate this static utility class. */
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  private constructor() {}
 }

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -34,7 +34,7 @@ export type TransactionJSON = BaseTransactionJSON | PaymentTransactionJSON
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
  */
-class Serializer {
+abstract class Serializer {
   /**
    * Convert a Transaction to a JSON representation.
    *

--- a/src/XRP/signer.ts
+++ b/src/XRP/signer.ts
@@ -9,7 +9,7 @@ import Wallet from './wallet'
 /**
  * Abstracts the details of signing.
  */
-class Signer {
+abstract class Signer {
   /**
    * Encode the given raw JSON transaction to hex and sign it.
    *

--- a/src/XRP/wallet.ts
+++ b/src/XRP/wallet.ts
@@ -130,7 +130,7 @@ class Wallet {
     try {
       const keyPair = rippleKeyPair.deriveKeypair(seed)
       return new Wallet(keyPair.publicKey, keyPair.privateKey, test)
-    } catch (exception) {
+    } catch {
       return undefined
     }
   }
@@ -201,7 +201,7 @@ class Wallet {
 
     try {
       return rippleKeyPair.verify(message, signature, this.getPublicKey())
-    } catch (error) {
+    } catch {
       // The ripple-key-pair module may throw errors for some signatures rather than returning false.
       // If an error was thrown then the signature is definitely not valid.
       return false

--- a/src/XRP/wallet.ts
+++ b/src/XRP/wallet.ts
@@ -38,7 +38,10 @@ class Wallet {
    * Generate a new wallet hierarchical deterministic wallet with a random mnemonic and
    * default derivation path.
    *
-   * Secure random number generation is used when entropy is ommitted and when the runtime environment has the necessary support. Otherwise, an error is thrown. Runtime environments that do not have secure random number generation should pass their own buffer of entropy.
+   * Secure random number generation is used when entropy is omitted and when the runtime environment has the necessary support.
+   * Otherwise, an error is thrown.
+   *
+   * Runtime environments that do not have secure random number generation should pass their own buffer of entropy.
    *
    * @param entropy - A optional hex string of entropy.
    * @param test - Whether the address is for use on a test network, defaults to `false`.

--- a/test/Common/utils.test.ts
+++ b/test/Common/utils.test.ts
@@ -9,10 +9,10 @@ describe('utils', function (): void {
     const address = 'rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1'
 
     // WHEN the address is validated.
-    const validAddress = Utils.isValidAddress(address)
+    const isValidAddress = Utils.isValidAddress(address)
 
     // THEN the address is deemed valid.
-    assert.isTrue(validAddress)
+    assert.isTrue(isValidAddress)
   })
 
   it('isValidAddress() - Valid X-Address', function (): void {
@@ -20,10 +20,10 @@ describe('utils', function (): void {
     const address = 'XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHi'
 
     // WHEN the address is validated.
-    const validAddress = Utils.isValidAddress(address)
+    const isValidAddress = Utils.isValidAddress(address)
 
     // THEN the address is deemed valid.
-    assert.isTrue(validAddress)
+    assert.isTrue(isValidAddress)
   })
 
   it('isValidAddress() - Wrong Alphabet', function (): void {
@@ -31,10 +31,10 @@ describe('utils', function (): void {
     const address = '1EAG1MwmzkG6gRZcYqcRMfC17eMt8TDTit'
 
     // WHEN the address is validated.
-    const validAddress = Utils.isValidAddress(address)
+    const isValidAddress = Utils.isValidAddress(address)
 
     // THEN the address is deemed invalid.
-    assert.isFalse(validAddress)
+    assert.isFalse(isValidAddress)
   })
 
   it('isValidAddress() - Invalid Classic Address Checksum', function (): void {
@@ -42,10 +42,10 @@ describe('utils', function (): void {
     const address = 'rU6K7V3Po4sBBBBBaU29sesqs2qTQJWDw1'
 
     // WHEN the address is validated.
-    const validAddress = Utils.isValidAddress(address)
+    const isValidAddress = Utils.isValidAddress(address)
 
     // THEN the address is deemed invalid.
-    assert.isFalse(validAddress)
+    assert.isFalse(isValidAddress)
   })
 
   it('isValidAddress() - Invalid X-Address Checksum', function (): void {
@@ -53,10 +53,10 @@ describe('utils', function (): void {
     const address = 'XVLhHMPHU98es4dbozjVtdWzVrDjtV18pX8yuPT7y4xaEHI'
 
     // WHEN the address is validated.
-    const validAddress = Utils.isValidAddress(address)
+    const isValidAddress = Utils.isValidAddress(address)
 
     // THEN the address is deemed invalid.
-    assert.isFalse(validAddress)
+    assert.isFalse(isValidAddress)
   })
 
   it('isValidAddress() - Invalid Characters', function (): void {
@@ -64,10 +64,10 @@ describe('utils', function (): void {
     const address = 'rU6K7V3Po4sBBBBBaU@#$%qs2qTQJWDw1'
 
     // WHEN the address is validated.
-    const validAddress = Utils.isValidAddress(address)
+    const isValidAddress = Utils.isValidAddress(address)
 
     // THEN the address is deemed invalid.
-    assert.isFalse(validAddress)
+    assert.isFalse(isValidAddress)
   })
 
   it('isValidAddress() - Too Long', function (): void {
@@ -76,10 +76,10 @@ describe('utils', function (): void {
       'rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1rU6K7V3Po4snVhBBaU29sesqs2qTQJWDw1'
 
     // WHEN the address is validated.
-    const validAddress = Utils.isValidAddress(address)
+    const isValidAddress = Utils.isValidAddress(address)
 
     // THEN the address is deemed invalid.
-    assert.isFalse(validAddress)
+    assert.isFalse(isValidAddress)
   })
 
   it('isValidAddress() - Too Short', function (): void {
@@ -87,10 +87,10 @@ describe('utils', function (): void {
     const address = 'rU6K7V3Po4s2qTQJWDw1'
 
     // WHEN the address is validated.
-    const validAddress = Utils.isValidAddress(address)
+    const isValidAddress = Utils.isValidAddress(address)
 
     // THEN the address is deemed invalid.
-    assert.isFalse(validAddress)
+    assert.isFalse(isValidAddress)
   })
 
   it('encodeXAddress() - Mainnet Address and Tag', function (): void {

--- a/test/PayID/pay-id-utils.test.ts
+++ b/test/PayID/pay-id-utils.test.ts
@@ -20,7 +20,7 @@ describe('PayIDUtils', function (): void {
 
   it('parse Pay ID - multiple dollar signs', function (): void {
     // GIVEN a Pay ID with too many '$'.
-    const host = 'xpring$money' // Extra '$'.
+    const host = 'xpring$money'
     const path = 'georgewashington'
     const rawPayID = `${host}$${path}`
 

--- a/test/XRP/fakes/fake-wallet.ts
+++ b/test/XRP/fakes/fake-wallet.ts
@@ -21,7 +21,7 @@ class FakeWallet extends Wallet {
    *
    * @param signature - The signature this wallet will produce.
    */
-  constructor(
+  public constructor(
     private readonly signature: string,
     publicKey = defaultPublicKey,
     privateKey = defaultPrivateKey,
@@ -34,7 +34,7 @@ class FakeWallet extends Wallet {
    *
    * @param hex - The hex to sign.
    */
-  sign(_hex: string): string {
+  public sign(_hex: string): string {
     return this.signature
   }
 }

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -40,11 +40,11 @@ const accountXAddress = 'X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4'
  * Create a new `Transaction` object with the given inputs.
  *
  * @param value - The amount of XRP to send, in drops.
- * @param destination - The destination address.
+ * @param destinationAddress - The destination address.
  * @param fee - The amount of XRP to use as a fee, in drops.
- * @param lastLedgerSequence - The last ledger sequence the transaction will be valid in.
- * @param sequence - The sequence number for the sending account.
- * @param account - The address of the sending account.
+ * @param lastLedgerSequenceNumber - The last ledger sequence the transaction will be valid in.
+ * @param sequenceNumber - The sequence number for the sending account.
+ * @param senderAddress - The address of the sending account.
  * @param publicKey - The public key of the sending account, encoded as a hexadecimal string.
  */
 function makeTransaction(

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -20,7 +20,7 @@ import {
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer from '../../src/XRP/serializer'
 
-/** Constants for transactions */
+/** Constants for transactions. */
 const value = '1000'
 const destinationClassicAddress = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
 const destinationXAddressWithoutTag =

--- a/test/XRP/wallet.test.ts
+++ b/test/XRP/wallet.test.ts
@@ -5,7 +5,8 @@ import 'mocha'
 
 /**
  * A mapping of input and expected outputs for BIP39 and BIP44.
- * @see https://iancoleman.io/bip39/#english
+ *
+ * @see [BIP39 - Mnemonic Code Converter]{@link https://iancoleman.io/bip39/#english}
  */
 const derivationPathTestCases = {
   index0: {

--- a/test/XRP/wallet.test.ts
+++ b/test/XRP/wallet.test.ts
@@ -193,10 +193,10 @@ describe('wallet', function (): void {
   it('walletFromSeed - TestNet', function (): void {
     // GIVEN a seed used to generate a wallet on TestNet
     const seed = 'snYP7oArxKepd3GPDcrjMsJYiJeJB'
-    const test = true
+    const isTest = true
 
     // WHEN a wallet is generated from the seed.
-    const wallet = Wallet.generateWalletFromSeed(seed, test)
+    const wallet = Wallet.generateWalletFromSeed(seed, isTest)
 
     // THEN the wallet has the expected address.
     assert.equal(


### PR DESCRIPTION
## High Level Overview of Change

Various linting changes to bring this repo closer to being able to use the `xpring-eslint` configuration.

In particular, this PR:
- Breaks up comments into multiple lines if they are too long
- Adds the `abstract` keyword to classes used as namespaces (static only classes)
- Sorts `public` class members before `private` class members
- Avoids using magic numbers like `32`
- Removes unused vars in `catch` blocks
- Enforces a naming convention for boolean variables
- Removes inline comments
- Enforces explicit accessibility modifiers on class members
- Enforces that comments need to be full sentences
- Updates outdated JSDocs

### Context of Change

Part of converting our repos to use the stricter `xpring-eslint`.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

`npm run test` still passes, because no functionality changed.

<!--
## Future Tasks
For future tasks related to PR.
-->
