### PR TITLE
Add loisrp@ as a CODEOWNER for markdown files #461

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,7 @@
 * @keefertaylor @amiecorso
 
+# Docs team owns markdown files
+*.md @loisrp
+
 # Allow anyone in DevX reviewers to approve automated dependency updates from Dependabot.
 package* @xpring-eng/devx-reviewers


### PR DESCRIPTION
## High Level Overview of Change

Add loisrp@ as a CODEOWNER on markdown files.

### Context of Change

This provides an automated FYI to the docs team when we change documentation in this repo. 

PRs for the other Xpring SDK repos to follow shortly. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

No functionality changes. 

## Test Plan

N/A
