### PR TITLE
Support DepositPreauth Operations in Serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - XRP specific functionality on the `Utils` class is deprecated. Use the new `XrpUtils` class instead.
 - A new method, `walletFromSeed` in `WalletFactory` encapsulates functionality for creating a `Wallet` object from a seed.
-- A new method, `walletFromSeedAndDerivationPath` in `WalletFactory` encapsulates functionality for creating a `Wallet` object from a seed.
 - A new enum, `XrplNetwork`, identifies the XRP Ledger network that components are connected to.
 - A new method, `isTestNetwork`, is provided by `XrpUtils` to identify whether a given `XrplNetwork` is a test network.
 - `Serializer` can now support serialization of [DepositPreAuth](https://xrpl.org/depositpreauth.html) operations.
@@ -19,8 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - XRP-specific functionality on the `Utils` class is deprecated. Use the new `XrpUtils` class instead.
-- The `walletFromSeed` method of the `Wallet` class is deprecated. Use the new `WalletFactory` to generate `Wallet`s from seeds.
-- The `generateHDWalletFromSeed` method of the `Wallet` class is deprecated. Use the new `WalletFactory` to generate `Wallet`s from seeds.
+- The `walletFromSeed` method of the `Wallet` class is deprecated. Please use the new `WalletFactory` to generate `Wallet`s from seeds.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - XRP specific functionality on the `Utils` class is deprecated. Use the new `XrpUtils` class instead.
 - A new method, `walletFromSeed` in `WalletFactory` encapsulates functionality for creating a `Wallet` object from a seed.
+- A new method, `walletFromSeedAndDerivationPath` in `WalletFactory` encapsulates functionality for creating a `Wallet` object from a seed.
 - A new enum, `XrplNetwork`, identifies the XRP Ledger network that components are connected to.
 - A new method, `isTestNetwork`, is provided by `XrpUtils` to identify whether a given `XrplNetwork` is a test network.
+- `Serializer` can now support serialization of [DepositPreAuth](https://xrpl.org/depositpreauth.html) operations.
 
 ### Deprecated
 
 - XRP-specific functionality on the `Utils` class is deprecated. Use the new `XrpUtils` class instead.
-- The `walletFromSeed` method of the `Wallet` class is deprecated. Please use the new `WalletFactory` to generate `Wallet`s from seeds.
+- The `walletFromSeed` method of the `Wallet` class is deprecated. Use the new `WalletFactory` to generate `Wallet`s from seeds.
+- The `generateHDWalletFromSeed` method of the `Wallet` class is deprecated. Use the new `WalletFactory` to generate `Wallet`s from seeds.
 
 ### Breaking Changes
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1,3 +1,8 @@
+/* eslint-disable  max-lines --
+ * Allow many lines of tests.
+ * TODO(keefertaylor): Remove this is hbergren@ agrees to disable this rule for tests globally.
+ */
+
 import 'mocha'
 import { assert } from 'chai'
 
@@ -16,11 +21,14 @@ import {
   MemoType,
   Sequence,
   SigningPublicKey,
+  Authorize,
+  Unauthorize,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
   Payment,
   Transaction,
+  DepositPreauth,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer from '../../src/XRP/serializer'
 
@@ -368,5 +376,64 @@ describe('serializer', function (): void {
     }
 
     assert.deepEqual(Serializer.memoToJSON(emptyMemo), expectedEmptyJSON)
+  })
+
+  it('serializes an authorize DepositPreauth correctly', function (): void {
+    // GIVEN a DepositPreauth protocol buffer representing an authorization.
+    const address = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+
+    const accountAddress = new AccountAddress()
+    accountAddress.setAddress(address)
+
+    const authorize = new Authorize()
+    authorize.setValue(accountAddress)
+
+    const depositPreauth = new DepositPreauth()
+    depositPreauth.setAuthorize(authorize)
+
+    const expectedJSON = {
+      Authorize: address,
+    }
+
+    // WHEN it is serialized.
+    const serialized = Serializer.depositPreauthToJSON(depositPreauth)
+
+    // THEN the protocol buffer is serialized as expected.
+    assert.deepEqual(serialized, expectedJSON)
+  })
+
+  it('serializes an unauthorize DepositPreauth correctly', function (): void {
+    // GIVEN a DepositPreauth protocol buffer representing an unauthorization.
+    const address = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+
+    const accountAddress = new AccountAddress()
+    accountAddress.setAddress(address)
+
+    const unauthorize = new Unauthorize()
+    unauthorize.setValue(accountAddress)
+
+    const depositPreauth = new DepositPreauth()
+    depositPreauth.setUnauthorize(unauthorize)
+
+    const expectedJSON = {
+      Unauthorize: address,
+    }
+
+    // WHEN it is serialized.
+    const serialized = Serializer.depositPreauthToJSON(depositPreauth)
+
+    // THEN the protocol buffer is serialized as expected.
+    assert.deepEqual(serialized, expectedJSON)
+  })
+
+  it('fails to serialize a malformed DepositPreauth', function (): void {
+    // GIVEN a DepositPreauth protocol buffer which has no operation set
+    const depositPreauth = new DepositPreauth()
+
+    // WHEN it is serialized.
+    const serialized = Serializer.depositPreauthToJSON(depositPreauth)
+
+    // THEN the result is undefined
+    assert.isUndefined(serialized)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -68,7 +68,7 @@ const formatForMemo = Utils.toBytes('jaypeg')
  *
  * @returns A new `Transaction` object comprised of the provided Transaction properties.
  */
-function makeTransaction(
+function makePaymentTransaction(
   value: string,
   destinationAddress: string,
   fee: string,
@@ -96,6 +96,92 @@ function makeTransaction(
   payment.setDestination(destination)
   payment.setAmount(amount)
 
+  const transaction = makeBaseTransaction(
+    fee,
+    lastLedgerSequenceNumber,
+    sequenceNumber,
+    senderAddress,
+    publicKey,
+  )
+  transaction.setPayment(payment)
+
+  return transaction
+}
+
+/**
+ * Create a new `DepositPreauth` object with the given inputs.
+ *
+ * Note: Either the `authorizeAddress` or `unauthorizeAddress`, but not both, must be set to get a
+ * valid output. This precondition is not enforced by the function.
+ *
+ * @param authorizeAddress - The address to authorize.
+ * @param unauthorizeAddress - The address to unauthorize.
+ * @param fee - The amount of XRP to use as a fee, in drops.
+ * @param lastLedgerSequenceNumber - The last ledger sequence the transaction will be valid in.
+ * @param sequenceNumber - The sequence number for the sending account.
+ * @param senderAddress - The address of the sending account.
+ * @param publicKey - The public key of the sending account, encoded as a hexadecimal string.
+ *
+ * @returns A new `Transaction` object comprised of the provided properties.
+ */
+function makeDepositPreauth(
+  authorizeAddress: string | undefined,
+  unauthorizeAddress: string | undefined,
+  fee: string,
+  lastLedgerSequenceNumber: number,
+  sequenceNumber: number,
+  senderAddress: string | undefined,
+  publicKey: string,
+): Transaction {
+  const depositPreauth = new DepositPreauth()
+  if (authorizeAddress) {
+    const accountAddress = new AccountAddress()
+    accountAddress.setAddress(authorizeAddress)
+
+    const authorize = new Authorize()
+    authorize.setValue(accountAddress)
+
+    depositPreauth.setAuthorize(authorize)
+  } else if (unauthorizeAddress) {
+    const accountAddress = new AccountAddress()
+    accountAddress.setAddress(unauthorizeAddress)
+
+    const unauthorize = new Unauthorize()
+    unauthorize.setValue(accountAddress)
+
+    depositPreauth.setUnauthorize(unauthorize)
+  }
+
+  const transaction = makeBaseTransaction(
+    fee,
+    lastLedgerSequenceNumber,
+    sequenceNumber,
+    senderAddress,
+    publicKey,
+  )
+  transaction.setDepositPreauth(depositPreauth)
+
+  return transaction
+}
+
+/**
+ * Make a transaction protocol buffer containing all the common fields.
+ *
+ * @param fee - The amount of XRP to use as a fee, in drops.
+ * @param lastLedgerSequenceNumber - The last ledger sequence the transaction will be valid in.
+ * @param sequenceNumber - The sequence number for the sending account.
+ * @param senderAddress - The address of the sending account.
+ * @param publicKey - The public key of the sending account, encoded as a hexadecimal string.
+ *
+ * @returns A transaction with common fields set.
+ */
+function makeBaseTransaction(
+  fee: string,
+  lastLedgerSequenceNumber: number,
+  sequenceNumber: number,
+  senderAddress: string | undefined,
+  publicKey: string,
+): Transaction {
   const transactionFee = new XRPDropsAmount()
   transactionFee.setDrops(fee)
 
@@ -111,7 +197,6 @@ function makeTransaction(
   const transaction = new Transaction()
   transaction.setFee(transactionFee)
   transaction.setSequence(sequence)
-  transaction.setPayment(payment)
   transaction.setSigningPublicKey(signingPublicKey)
   transaction.setLastLedgerSequence(lastLedgerSequence)
 
@@ -133,7 +218,7 @@ function makeTransaction(
 describe('serializer', function (): void {
   it('serializes a payment in XRP from a classic address', function (): void {
     // GIVEN a transaction which represents a payment denominated in XRP.
-    const transaction = makeTransaction(
+    const transaction = makePaymentTransaction(
       value,
       destinationClassicAddress,
       fee,
@@ -162,7 +247,7 @@ describe('serializer', function (): void {
 
   it('serializes a payment in XRP from an X-Address with no tag', function (): void {
     // GIVEN a transaction which represents a payment denominated in XRP.
-    const transaction = makeTransaction(
+    const transaction = makePaymentTransaction(
       value,
       destinationClassicAddress,
       fee,
@@ -192,7 +277,7 @@ describe('serializer', function (): void {
   it('fails to serializes a payment in XRP from an X-Address with a tag', function (): void {
     // GIVEN a transaction which represents a payment denominated in XRP from a sender with a tag.
     const account = Utils.encodeXAddress(accountClassicAddress, tag)
-    const transaction = makeTransaction(
+    const transaction = makePaymentTransaction(
       value,
       destinationClassicAddress,
       fee,
@@ -211,7 +296,7 @@ describe('serializer', function (): void {
 
   it('fails to serializes a payment in XRP when account is undefined', function (): void {
     // GIVEN a transaction which represents a payment denominated in XRP.
-    const transaction = makeTransaction(
+    const transaction = makePaymentTransaction(
       value,
       destinationClassicAddress,
       fee,
@@ -230,7 +315,7 @@ describe('serializer', function (): void {
 
   it('serializes a payment to an X-address with a tag in XRP', function (): void {
     // GIVEN a transaction which represents a payment to a destination and tag, denominated in XRP.
-    const transaction = makeTransaction(
+    const transaction = makePaymentTransaction(
       value,
       destinationXAddressWithTag,
       fee,
@@ -260,7 +345,7 @@ describe('serializer', function (): void {
 
   it('serializes a payment to an X-address without a tag in XRP', function (): void {
     // GIVEN a transaction which represents a payment to a destination without a tag, denominated in XRP.
-    const transaction = makeTransaction(
+    const transaction = makePaymentTransaction(
       value,
       destinationXAddressWithoutTag,
       fee,
@@ -290,7 +375,7 @@ describe('serializer', function (): void {
   it('serializes a payment with a memo', function (): void {
     // GIVEN a transaction which represents a payment to a destination without a tag, denominated in XRP, with a dank
     // meme for a memo
-    const transaction = makeTransaction(
+    const transaction = makePaymentTransaction(
       value,
       destinationXAddressWithoutTag,
       fee,
@@ -435,5 +520,39 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined
     assert.isUndefined(serialized)
+  })
+
+  it('serializes a transaction representing a well formed DepositPreAuth', function (): void {
+    // GIVEN a transaction representing a well formed DepositPreauth.
+    const address = 'rHb9CJAWyB4rj91VRWn96DkukG4bwdtyTh'
+    const transaction = makeDepositPreauth(
+      address,
+      undefined,
+      fee,
+      lastLedgerSequence,
+      sequence,
+      accountClassicAddress,
+      publicKey,
+    )
+
+    // WHEN the transaction is serialized THEN the result exists.
+    assert.exists(Serializer.transactionToJSON(transaction))
+  })
+
+  it('serializes a transaction representing a malformed DepositPreAuth', function (): void {
+    // GIVEN a transaction representing a malformed DepositPreauth.
+    // Neither `authorizeAddress` or `unauthorizeAddress` are defined which creates a malformed transaction.
+    const transaction = makeDepositPreauth(
+      undefined,
+      undefined,
+      fee,
+      lastLedgerSequence,
+      sequence,
+      accountClassicAddress,
+      publicKey,
+    )
+
+    // WHEN the transaction is serialized THEN the result is unefined.
+    assert.isUndefined(Serializer.transactionToJSON(transaction))
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable  max-lines --
  * Allow many lines of tests.
- * TODO(keefertaylor): Remove this is hbergren@ agrees to disable this rule for tests globally.
+ * TODO(keefertaylor): Remove this if hbergren@ agrees to disable this rule for tests globally.
  */
 
 import 'mocha'


### PR DESCRIPTION
## High Level Overview of Change

Add support for DepositPreauth Serialization.

### Context of Change

We'd like to begin to support additional operation types. `Serializer` acts as a shim layer that converts protocol buffers to JSON objects. We can then feed those JSON objects to ripple-binary-codec and get bytes to sign.

### Type of Change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Additional serialization is supported. 

## Test Plan

New tests added for CI.
<!--
## Future Tasks
For future tasks related to PR.
-->
