### PR TITLE
Fix Casing in Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A new method, `walletFromSeed` in `WalletFactory` encapsulates functionality for creating a `Wallet` object from a seed.
 - A new enum, `XrplNetwork`, identifies the XRP Ledger network that components are connected to.
 - A new method, `isTestNetwork`, is provided by `XrpUtils` to identify whether a given `XrplNetwork` is a test network.
+- A new method, `parsePayId`, is provided by `PayIdUtils`, to replace the `parsePayID` method.
 
 ### Deprecated
 
 - XRP-specific functionality on the `Utils` class is deprecated. Use the new `XrpUtils` class instead.
-- The `walletFromSeed` method of the `Wallet` class is deprecated. Please use the new `WalletFactory` to generate `Wallet`s from seeds.
+- The `walletFromSeed` method of the `Wallet` class is deprecated. Use the new `WalletFactory` to generate `Wallet`s from seeds.
+- The `parsePayID` method on `PayIdUtils` is deprecated. Use the `parsePayId` method instead.
 
 ### Breaking Changes
 

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -11,16 +11,28 @@ const payIdUtils = {
   /**
    * Parse a PayID string to a set of PayIdComponents object.
    *
-   * @param payID - The input Pay ID.
+   * @deprecated Use parsePayId instead.
+   *
+   * @param payId - The input Pay ID.
    * @returns A PayIdComponents object if the input was valid, otherwise undefined.
    */
-  parsePayID(payID: string): PayIdComponents | undefined {
-    if (!this.isASCII(payID)) {
+  parsePayID(payId: string): PayIdComponents | undefined {
+    return this.parsePayId(payId)
+  },
+
+  /**
+   * Parse a PayID string to a set of PayIdComponents object.
+   *
+   * @param payId - The input Pay ID.
+   * @returns A PayIdComponents object if the input was valid, otherwise undefined.
+   */
+  parsePayId(payId: string): PayIdComponents | undefined {
+    if (!this.isASCII(payId)) {
       return undefined
     }
 
     // Validate there are two components of a payment pointer.
-    const components = payID.split('$')
+    const components = payId.split('$')
     if (components.length !== 2) {
       return undefined
     }


### PR DESCRIPTION
## High Level Overview of Change

Javascript prefers `PayId` to `PayID`. This fixes a straggling function.

### Context of Change

Follow on from https://github.com/xpring-eng/xpring-common-js/pull/268.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Idiomatic code. 
## Test Plan

CI
