### PR TITLE
Updates PayID parsing rules to support multiple "$"

### DIFF
--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -27,15 +27,15 @@ const payIdUtils = {
       return undefined
     }
 
-    // Validate there are two components of a payment pointer.
-    const components = payId.split('$')
-    if (components.length !== 2) {
+    // Split on the last occurrence of '$'
+    const lastDollarIndex = payId.lastIndexOf('$')
+    if (lastDollarIndex === -1) {
       return undefined
     }
+    const path = payId.slice(0, lastDollarIndex)
+    const host = payId.slice(lastDollarIndex + 1)
 
     // Validate the host and path have values.
-    const path = components[0]
-    const host = components[1]
     if (host.length === 0 || path.length === 0) {
       return undefined
     }

--- a/test/PayID/pay-id-utils.test.ts
+++ b/test/PayID/pay-id-utils.test.ts
@@ -18,7 +18,7 @@ describe('PayIDUtils', function (): void {
     assert.equal(payIDComponents?.path, `/${path}`)
   })
 
-  it('parse Pay ID - multiple dollar signs', function (): void {
+  it('parse Pay ID - valid multiple dollar signs', function (): void {
     // GIVEN a Pay ID with more than one '$'.
     const host = 'xpring.money'
     const path = 'george$$$washington$'
@@ -30,6 +30,20 @@ describe('PayIDUtils', function (): void {
     // THEN the host and path are set correctly.
     assert.equal(payIDComponents?.host, host)
     assert.equal(payIDComponents?.path, `/${path}`)  
+  })
+
+  it('parse Pay ID - invalid multiple dollar signs (ends with $)', function (): void {
+    // GIVEN a Pay ID in which the host ends with a $.
+    const host = 'xpring.money$'
+    const path = 'george$$$washington$'
+    const rawPayID = `${path}$${host}`
+
+    // WHEN it is parsed to components.
+    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
+
+
+    // THEN the Pay ID failed to parse.
+    assert.isUndefined(payIDComponents)
   })
 
   it('parse Pay ID - empty host', function (): void {

--- a/test/PayID/pay-id-utils.test.ts
+++ b/test/PayID/pay-id-utils.test.ts
@@ -22,7 +22,7 @@ describe('PayIDUtils', function (): void {
     // GIVEN a Pay ID with more than one '$'.
     const host = 'xpring.money'
     const path = 'george$$$washington$'
-    const rawPayID = `${host}$${path}`
+    const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
     const payIDComponents = PayIdUtils.parsePayID(rawPayID)
@@ -36,7 +36,7 @@ describe('PayIDUtils', function (): void {
     // GIVEN a Pay ID with an empty host.
     const host = ''
     const path = 'georgewashington'
-    const rawPayID = `${host}$${path}`
+    const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
     const payIDComponents = PayIdUtils.parsePayID(rawPayID)
@@ -46,10 +46,10 @@ describe('PayIDUtils', function (): void {
   })
 
   it('parse Pay ID - empty path', function (): void {
-    // GIVEN a Pay ID with an empty host.
+    // GIVEN a Pay ID with an empty path.
     const host = 'xpring.money'
     const path = ''
-    const rawPayID = `${host}$${path}`
+    const rawPayID = `${path}$${host}`
 
     // WHEN it is parsed to components.
     const payIDComponents = PayIdUtils.parsePayID(rawPayID)

--- a/test/PayID/pay-id-utils.test.ts
+++ b/test/PayID/pay-id-utils.test.ts
@@ -19,16 +19,17 @@ describe('PayIDUtils', function (): void {
   })
 
   it('parse Pay ID - multiple dollar signs', function (): void {
-    // GIVEN a Pay ID with too many '$'.
-    const host = 'xpring$money'
-    const path = 'georgewashington'
+    // GIVEN a Pay ID with more than one '$'.
+    const host = 'xpring.money'
+    const path = 'george$$$washington$'
     const rawPayID = `${host}$${path}`
 
     // WHEN it is parsed to components.
     const payIDComponents = PayIdUtils.parsePayID(rawPayID)
 
-    // THEN the Pay ID failed to parse.
-    assert.isUndefined(payIDComponents)
+    // THEN the host and path are set correctly.
+    assert.equal(payIDComponents?.host, host)
+    assert.equal(payIDComponents?.path, `/${path}`)  
   })
 
   it('parse Pay ID - empty host', function (): void {

--- a/test/PayID/pay-id-utils.test.ts
+++ b/test/PayID/pay-id-utils.test.ts
@@ -41,6 +41,16 @@ describe('PayIDUtils', function (): void {
     // WHEN it is parsed to components.
     const payIDComponents = PayIdUtils.parsePayID(rawPayID)
 
+    // THEN the Pay ID failed to parse.
+    assert.isUndefined(payIDComponents)
+  })
+
+  it('parse Pay ID - no dollar signs', function (): void {
+    // GIVEN a Pay ID that contains no dollar signs
+    const rawPayID = `georgewashington@xpring.money`
+
+    // WHEN it is parsed to components.
+    const payIDComponents = PayIdUtils.parsePayID(rawPayID)
 
     // THEN the Pay ID failed to parse.
     assert.isUndefined(payIDComponents)


### PR DESCRIPTION
## High Level Overview of Change
Updates `parsePayId` utility to reflect decision to allow "$" in path strings.  Parsing a PayID that contains multiple dollar signs treats the final occurrence of a dollar sign as the delimiter between the path and host. 


<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
RFC specifies that "$" can be included in PayID host https://github.com/xpring-eng/rfcs/blob/master/payid/dist/spec/payid-uri.txt.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After
PayIDs that contain a "$" in the path string will now be correctly parsed.

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Existing test for multiple dollar signs has been updated to reflect desired behavior.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
