### PR TITLE
Add Mnemonic/DerivationPath based Generation to `WalletFactory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- A new method, `walletFromMnemonicAndDerivationPath` in `WalletFactory` encapsulates functionality for creating a `Wallet` object from a mnemonic and derivation path.
+
+### Deprecated
+
+- The `generateWalletFromMnemonic` method of the `Wallet` class is deprecated. Use the new `WalletFactory` class to generate `Wallet`s from mnemonics and derivation paths..
+
 ## [5.1.1] - 2020-06-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
-- The `generateWalletFromMnemonic` method of the `Wallet` class is deprecated. Use the new `WalletFactory` class to generate `Wallet`s from mnemonics and derivation paths..
+- The `generateWalletFromMnemonic` method of the `Wallet` class is deprecated. Use the new `WalletFactory` class to generate `Wallet`s from mnemonics and derivation paths.
 
 ## [5.1.1] - 2020-06-16
 

--- a/src/XRP/wallet-factory.ts
+++ b/src/XRP/wallet-factory.ts
@@ -1,4 +1,5 @@
 import * as bip32 from 'bip32'
+import * as bip39 from 'bip39'
 import * as rippleKeyPair from 'ripple-keypairs'
 
 import Utils from '../Common/utils'
@@ -32,11 +33,31 @@ export default class WalletFactory {
   }
 
   /**
+   * Generate a new hierarchical deterministic wallet from a mnemonic and derivation path.
+   *
+   * @param mnemonic - The mnemonic to generate the wallet.
+   * @param derivationPath - The given derivation path to use. If undefined, the default path is used.
+   * @returns A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
+   */
+  public async walletFromMnemonicAndDerivationPath(
+    mnemonic: string,
+    derivationPath = WalletFactory.defaultDerivationPath,
+  ): Promise<Wallet | undefined> {
+    // Validate mnemonic and path are valid.
+    if (!bip39.validateMnemonic(mnemonic)) {
+      return undefined
+    }
+
+    const seed = await bip39.mnemonicToSeed(mnemonic)
+    return Wallet.generateHDWalletFromSeed(seed, derivationPath, this.isTest)
+  }
+
+  /**
    * Generate a new hierarchical deterministic wallet from a seed and derivation path.
    *
    * @param seed - A hex encoded seed string.
    * @param derivationPath - The given derivation path to use. If undefined, the default path is used.
-   * @returns A new wallet from the given mnemonic if the mnemonic was valid, otherwise undefined.
+   * @returns A new wallet from the given seed if the seed was valid, otherwise undefined.
    */
   // eslint-disable-next-line max-statements -- This does not read as too complex a function.
   public walletFromSeedAndDerivationPath(

--- a/src/XRP/wallet.ts
+++ b/src/XRP/wallet.ts
@@ -83,6 +83,8 @@ class Wallet {
   /**
    * Generate a new hierarchical deterministic wallet from a mnemonic and derivation path.
    *
+   * @deprecated Please use methods on `WalletFactory` to generate wallets instead.
+   *
    * @param mnemonic - The given mnemonic for the wallet.
    * @param derivationPath - The given derivation path to use. If undefined, the default path is used.
    * @param test - Whether the address is for use on a test network, defaults to `false`.

--- a/test/XRP/wallet-factory.test.ts
+++ b/test/XRP/wallet-factory.test.ts
@@ -4,6 +4,38 @@ import WalletFactory from '../../src/XRP/wallet-factory'
 import 'mocha'
 import XrplNetwork from '../../src/XRP/xrpl-network'
 
+/**
+ * A mapping of input and expected outputs for BIP39 and BIP44.
+ *
+ * @see {@link https://iancoleman.io/bip39/#english|BIP39 - Mnemonic Code Converter}.
+ */
+const DERIVATION_PATH_TEST_CASES = {
+  index0: {
+    mnemonic:
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    derivationPath: "m/44'/144'/0'/0/0",
+    expectedPublicKey:
+      '031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE',
+    expectedPrivateKey:
+      '0090802A50AA84EFB6CDB225F17C27616EA94048C179142FECF03F4712A07EA7A4',
+    expectedMainNetAddress: 'XVMFQQBMhdouRqhPMuawgBMN1AVFTofPAdRsXG5RkPtUPNQ',
+    expectedTestNetAddress: 'TVHLFWLKvbMv1LFzd6FA2Bf9MPpcy4mRto4VFAAxLuNpvdW',
+    messageHex: Buffer.from('test message', 'utf8').toString('hex'),
+    expectedSignature:
+      '3045022100E10177E86739A9C38B485B6AA04BF2B9AA00E79189A1132E7172B70F400ED1170220566BD64AA3F01DDE8D99DFFF0523D165E7DD2B9891ABDA1944E2F3A52CCCB83A',
+  },
+  index1: {
+    mnemonic:
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
+    derivationPath: "m/44'/144'/0'/0/1",
+    expectedPublicKey:
+      '038BF420B5271ADA2D7479358FF98A29954CF18DC25155184AEAD05796DA737E89',
+    expectedPrivateKey:
+      '000974B4CFE004A2E6C4364CBF3510A36A352796728D0861F6B555ED7E54A70389',
+    expectedAddress: 'X7uRz9jfzHUFEjZTZ7rMVzFuTGZTHWcmkKjvGkNqVbfMhca',
+  },
+}
+
 describe('Wallet Factory', function (): void {
   it('Wallet From Keys - Valid Keys', function (): void {
     // GIVEN a wallet factory and set of valid keys.
@@ -146,6 +178,99 @@ describe('Wallet Factory', function (): void {
     const wallet = walletFactory.walletFromSeedAndDerivationPath(
       seed,
       derivationPath,
+    )
+
+    // THEN the wallet is undefined.
+    assert.isUndefined(wallet)
+  })
+
+  // walletFromMnemonicAndDerivationPath
+
+  it('walletFromMnemonicAndDerivationPath - derivation path index 0 - MainNet', async function (): Promise<
+    void
+  > {
+    // GIVEN a `WalletFactory`, a menmonic, derivation path and a set of expected outputs.
+    const walletFactory = new WalletFactory(XrplNetwork.Main)
+    const testData = DERIVATION_PATH_TEST_CASES.index0
+
+    // WHEN a new wallet is generated on MainNet with the mnemonic and derivation path.
+    const wallet = await walletFactory.walletFromMnemonicAndDerivationPath(
+      testData.mnemonic,
+      testData.derivationPath,
+    )!
+
+    // THEN the wallet has the expected address and keys.
+    assert.equal(wallet?.privateKey, testData.expectedPrivateKey)
+    assert.equal(wallet?.publicKey, testData.expectedPublicKey)
+    assert.equal(wallet?.getAddress(), testData.expectedMainNetAddress)
+  })
+
+  it('walletFromMnemonicAndDerivationPath - derivation path index 0, TestNet', async function (): Promise<
+    void
+  > {
+    // GIVEN a `WalletFactory`, a menmonic, derivation path and a set of expected outputs.
+    const walletFactory = new WalletFactory(XrplNetwork.Test)
+    const testData = DERIVATION_PATH_TEST_CASES.index0
+
+    // WHEN a new wallet is generated on TestNet with the mnemonic and derivation path.
+    const wallet = await walletFactory.walletFromMnemonicAndDerivationPath(
+      testData.mnemonic,
+      testData.derivationPath,
+    )!
+
+    // THEN the wallet has the expected address and keys.
+    assert.equal(wallet?.privateKey, testData.expectedPrivateKey)
+    assert.equal(wallet?.publicKey, testData.expectedPublicKey)
+    assert.equal(wallet?.getAddress(), testData.expectedTestNetAddress)
+  })
+
+  it('walletFromMnemonicAndDerivationPath - derivation path index 1', async function (): Promise<
+    void
+  > {
+    // GIVEN a `WalletFactory`, a menmonic, derivation path and a set of expected outputs.
+    const walletFactory = new WalletFactory(XrplNetwork.Main)
+    const testData = DERIVATION_PATH_TEST_CASES.index1
+
+    // WHEN a new wallet is generated with the mnemonic and derivation path.
+    const wallet = await walletFactory.walletFromMnemonicAndDerivationPath(
+      testData.mnemonic,
+      testData.derivationPath,
+    )!
+
+    // THEN the wallet has the expected address and keys.
+    assert.equal(wallet?.privateKey, testData.expectedPrivateKey)
+    assert.equal(wallet?.publicKey, testData.expectedPublicKey)
+    assert.equal(wallet?.getAddress(), testData.expectedAddress)
+  })
+
+  it('walletFromMnemonicAndDerivationPath - no derivation path', async function (): Promise<
+    void
+  > {
+    // GIVEN a `WalletFactory`, a menmonic, derivation path and a set of expected outputs.
+    const walletFactory = new WalletFactory(XrplNetwork.Main)
+    const testData = DERIVATION_PATH_TEST_CASES.index0
+
+    // WHEN a new wallet is generated with the mnemonic and an unspecified derivation path.
+    const wallet = await walletFactory.walletFromMnemonicAndDerivationPath(
+      testData.mnemonic,
+    )
+
+    // THEN the wallet has the expected address and keys from the input mnemonic at the default derivation path.
+    assert.equal(wallet?.privateKey, testData.expectedPrivateKey)
+    assert.equal(wallet?.publicKey, testData.expectedPublicKey)
+    assert.equal(wallet?.getAddress(), testData.expectedMainNetAddress)
+  })
+
+  it('walletFromMnemonicAndDerivationPath - invalid mnemonic', async function (): Promise<
+    void
+  > {
+    // GIVEN an invalid mnemonic.
+    const walletFactory = new WalletFactory(XrplNetwork.Main)
+    const mnemonic = 'xrp xrp xpr xpr xrp xrp xpr xpr xrp xrp xpr xpr'
+
+    // WHEN a wallet is generated from the mnemonic.
+    const wallet = await walletFactory.walletFromMnemonicAndDerivationPath(
+      mnemonic,
     )
 
     // THEN the wallet is undefined.


### PR DESCRIPTION
## High Level Overview of Change

Add functions to generate a HD wallet from a seed and derivation path to `WalletFactory`. 

### Context of Change

Test cases were produced by generating a seed and derivation paths, using this well known tool: https://iancoleman.io/bip39/#english.

I then converted the classic addresses to X-addresses using xrpaddress.ino.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

New methods to generate wallet. 

## Test Plan

CI and new tests are provided. 