### PR TITLE
Updates serializer code to have `TransactionType` field for `AccountSet` and `DepositPreauth`

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -21,6 +21,7 @@ interface AccountSetJSON {
   EmailHash?: string
   MessageKey?: string
   SetFlag?: number
+  TransactionType: string
   TransferRate?: number
   TickSize?: number
 }
@@ -33,6 +34,7 @@ interface PaymentJSON {
 
 interface DepositPreauthJSON {
   Authorize?: string
+  TransactionType: string
   Unauthorize?: string
 }
 
@@ -173,6 +175,9 @@ const serializer = {
   depositPreauthToJSON(
     depositPreauth: DepositPreauth,
   ): DepositPreauthJSON | undefined {
+    const json: DepositPreauthJSON = {
+      TransactionType: 'DepositPreauth',
+    }
     const type = depositPreauth.getAuthorizationOneofCase()
     switch (type) {
       case DepositPreauth.AuthorizationOneofCase.AUTHORIZE: {
@@ -180,10 +185,8 @@ const serializer = {
           .getAuthorize()
           ?.getValue()
           ?.getAddress()
-
-        return {
-          Authorize: authorize,
-        }
+        json.Authorize = authorize
+        return json
       }
       case DepositPreauth.AuthorizationOneofCase.UNAUTHORIZE: {
         const unauthorize = depositPreauth
@@ -191,9 +194,8 @@ const serializer = {
           ?.getValue()
           ?.getAddress()
 
-        return {
-          Unauthorize: unauthorize,
-        }
+        json.Unauthorize = unauthorize
+        return json
       }
       case DepositPreauth.AuthorizationOneofCase.AUTHORIZATION_ONEOF_NOT_SET: {
         return undefined
@@ -212,7 +214,7 @@ const serializer = {
    */
   // eslint-disable-next-line max-statements -- No clear way to make this more succinct because gRPC is verbose
   accountSetToJSON(accountSet: AccountSet): AccountSetJSON | undefined {
-    const json: AccountSetJSON = {}
+    const json: AccountSetJSON = { TransactionType: 'AccountSet' }
 
     const clearFlag = accountSet.getClearFlag()?.getValue()
     if (clearFlag !== undefined) {

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -25,17 +25,18 @@ interface AccountSetJSON {
   TransferRate?: number
   TickSize?: number
 }
-interface PaymentJSON {
-  Amount: Record<string, unknown> | string
-  Destination: string
-  DestinationTag?: number
-  TransactionType: string
-}
 
 interface DepositPreauthJSON {
   Authorize?: string
   TransactionType: string
   Unauthorize?: string
+}
+
+interface PaymentJSON {
+  Amount: Record<string, unknown> | string
+  Destination: string
+  DestinationTag?: number
+  TransactionType: string
 }
 
 interface MemoJSON {
@@ -58,14 +59,31 @@ interface BaseTransactionJSON {
   Memos?: MemoJSON[]
 }
 
+interface AccountSetJSONAddition extends AccountSetJSON {
+  TransactionType: 'AccountSet'
+}
+
+interface DepositPreauthJSONAddition extends DepositPreauthJSON {
+  TransactionType: 'DepositPreauth'
+}
+
 interface PaymentTransactionJSONAddition extends PaymentJSON {
   TransactionType: 'Payment'
 }
 
+type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
+
+type DepositPreauthTransactionJSON = BaseTransactionJSON &
+  DepositPreauthJSONAddition
+
 type PaymentTransactionJSON = BaseTransactionJSON &
   PaymentTransactionJSONAddition
 
-export type TransactionJSON = BaseTransactionJSON | PaymentTransactionJSON
+export type TransactionJSON =
+  | BaseTransactionJSON
+  | AccountSetTransactionJSON
+  | DepositPreauthTransactionJSON
+  | PaymentTransactionJSON
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -610,6 +610,7 @@ describe('serializer', function (): void {
 
     const expectedJSON = {
       Authorize: address,
+      TransactionType: 'DepositPreauth',
     }
 
     // WHEN it is serialized.
@@ -633,6 +634,7 @@ describe('serializer', function (): void {
     depositPreauth.setUnauthorize(unauthorize)
 
     const expectedJSON = {
+      TransactionType: 'DepositPreauth',
       Unauthorize: address,
     }
 
@@ -699,7 +701,9 @@ describe('serializer', function (): void {
       undefined,
       undefined,
     )
-    const expectedJSON = {}
+    const expectedJSON = {
+      TransactionType: 'AccountSet',
+    }
 
     // WHEN it is serialized.
     const serialized = Serializer.accountSetToJSON(accountSet)
@@ -736,6 +740,7 @@ describe('serializer', function (): void {
       EmailHash: Utils.toHex(emailHashValue),
       MessageKey: Utils.toHex(messageKeyValue),
       SetFlag: setFlagValue,
+      TransactionType: 'AccountSet',
       TransferRate: transferRateValue,
       TickSize: tickSizeValue,
     }


### PR DESCRIPTION
## High Level Overview of Change
The serialization code for new transaction types `AccountSet` and `DepositPreauth` was missing the transaction type, a bug that didn't become obvious until actually submitting these types of transactions to the rippled server and getting the following error: `Error: 3 INVALID_ARGUMENT: invalid transaction: Field not found: TransactionType`.

@keefertaylor I tried to follow the format through which a `Payment` transaction gets the `TransactionType` set, but let me know if we're trying to apply a different pattern here.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After
Serialization code sets transaction type for `AccountSet` and `DepositPreauth` transaction types.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI still passes.  SDK code for `enableDepositAuth` should be able to successfully submit an `AccountSet` transaction now.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
