### PR TITLE
Serialization for Currency

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -3,7 +3,7 @@
  */
 import Utils from '../Common/utils'
 
-import { XRPDropsAmount } from './generated/org/xrpl/rpc/v1/amount_pb'
+import { XRPDropsAmount, Currency } from './generated/org/xrpl/rpc/v1/amount_pb'
 import {
   AccountSet,
   Memo,
@@ -75,6 +75,11 @@ interface PathElementJSON {
   account?: string
   issuer?: string
   currencyCode?: string
+}
+
+interface CurrencyJSON {
+  name?: string
+  code?: Uint8Array
 }
 
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
@@ -348,6 +353,19 @@ const serializer = {
 
     return {
       Memo: jsonMemo,
+    }
+  },
+
+  /**
+   * Convert a Currency to a JSON representation.
+   *
+   * @param currency - The Currency to convert.
+   * @returns The Currency as JSON.
+   */
+  currencyToJSON(currency: Currency): CurrencyJSON {
+    return {
+      name: currency.getName(),
+      code: currency.getCode_asU8()
     }
   },
 }

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -77,11 +77,7 @@ interface PathElementJSON {
   currencyCode?: string
 }
 
-interface CurrencyJSON {
-  name?: string
-  code?: Uint8Array
-}
-
+type CurrencyJSON = string
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
 
 type DepositPreauthTransactionJSON = BaseTransactionJSON &
@@ -362,11 +358,18 @@ const serializer = {
    * @param currency - The Currency to convert.
    * @returns The Currency as JSON.
    */
-  currencyToJSON(currency: Currency): CurrencyJSON {
-    return {
-      name: currency.getName(),
-      code: currency.getCode_asU8()
+  currencyToJSON(currency: Currency): CurrencyJSON | undefined {
+    const currencyName = currency.getName()
+    if (currencyName !== '') {
+      return currencyName
     }
+
+    const currencyCodeBytes = currency.getCode_asU8()
+    if (currencyCodeBytes.length !== 0) {
+      return Utils.toHex(currencyCodeBytes)
+    }
+
+    return undefined
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -813,4 +813,21 @@ describe('serializer', function (): void {
     // AND the account is undefined.
     assert.isUndefined(serialized.account)
   })
+
+  it('serializes a Currency with fields set', function (): void {
+    // GIVEN a Currency with fields set.
+    const currencyName = "USD"
+    const currencyCode = new Uint8Array([1, 2, 3, 4])
+
+    const currency = new Currency()
+    currency.setName(currencyName)
+    currency.setCode(currencyCode)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.currencyToJSON(currency)
+
+    // THEN the outputs are the inputs.
+    assert.equal(serialized.name, currencyName)
+    assert.deepEqual(serialized.code, currencyCode)
+  })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -814,20 +814,38 @@ describe('serializer', function (): void {
     assert.isUndefined(serialized.account)
   })
 
-  it('serializes a Currency with fields set', function (): void {
-    // GIVEN a Currency with fields set.
-    const currencyName = "USD"
+  it('Serializes a Currency with a name field set', function (): void {
+    // GIVEN a Currency with a name field set.
+    const currencyName = 'USD'
+    const currency = new Currency()
+    currency.setName(currencyName)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.currencyToJSON(currency)
+
+    // THEN the outputs are the inputs.
+    assert.equal(serialized, currencyName)
+  })
+
+  it('Serializes a Currency with a code field set', function (): void {
+    // GIVEN a Currency with a code field set.
     const currencyCode = new Uint8Array([1, 2, 3, 4])
 
     const currency = new Currency()
-    currency.setName(currencyName)
     currency.setCode(currencyCode)
 
     // WHEN it is serialized.
     const serialized = Serializer.currencyToJSON(currency)
 
     // THEN the outputs are the inputs.
-    assert.equal(serialized.name, currencyName)
-    assert.deepEqual(serialized.code, currencyCode)
+    assert.equal(serialized, Utils.toHex(currencyCode))
+  })
+
+  it('Serializes a Currency with no fields set', function (): void {
+    // GIVEN a Currency with no fields set.
+    const currency = new Currency()
+
+    // WHEN it is serialized THEN the result is undefined.
+    assert.isUndefined(Serializer.currencyToJSON(currency))
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Add support for serializing Currency objects.

### Context of Change

We currently don't serialize all fields in transactions. This is a step towards fixing that. 

Currencies are serialized as either a hex encoded string or a currency string. See: https://xrpl.org/currency-formats.html#currency-codes

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

No change since this isn't hooked up to anything yet. Future PRs will build on this to add in support for Paths in payments. 

## Test Plan

CI; new tests provided. 