### PR TITLE
Serialization for InvoiceId objects

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -4,6 +4,7 @@
 import Utils from '../Common/utils'
 
 import { XRPDropsAmount, Currency } from './generated/org/xrpl/rpc/v1/amount_pb'
+import { InvoiceID } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
   Memo,
@@ -77,6 +78,7 @@ interface PathElementJSON {
   currencyCode?: string
 }
 
+type InvoiceIdJSON = string
 type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
@@ -384,6 +386,16 @@ const serializer = {
     }
 
     return undefined
+  },
+
+  /**
+   * Convert an InvoiceID to a JSON representation.
+   *
+   * @param invoiceId - The InvoiceID to convert.
+   * @returns The InvoiceID as JSON.
+   */
+  invoiceIdToJSON(invoiceId: InvoiceID): InvoiceIdJSON {
+    return Utils.toHex(invoiceId.getValue_asU8())
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -31,6 +31,7 @@ import {
   SetFlag,
   TransferRate,
   TickSize,
+  InvoiceID,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -888,7 +889,7 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized[0], Serializer.pathElementToJSON(pathElement1))
     assert.deepEqual(serialized[1], Serializer.pathElementToJSON(pathElement2))
   })
-    
+
   it('Serializes a Currency with a name field set', function (): void {
     // GIVEN a Currency with a name field set.
     const currencyName = 'USD'
@@ -922,5 +923,19 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized THEN the result is undefined.
     assert.isUndefined(Serializer.currencyToJSON(currency))
+  })
+
+  it('Serializes an InvoiceId', function (): void {
+    // GIVEN a InvoiceId with some bytes
+    const invoiceIdBytes = new Uint8Array([0, 1, 2, 3])
+
+    const invoiceId = new InvoiceID()
+    invoiceId.setValue(invoiceIdBytes)
+
+    // WHEN it is serialized
+    const serialized = Serializer.invoiceIdToJSON(invoiceId)
+
+    // THEN the result is the hex representation of the invoiceId.
+    assert.equal(serialized, Utils.toHex(invoiceIdBytes))
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for InvoiceId objects.

### Context of Change

InvoiceIds are just sets of bytes which we translate as a hex string in JSON. [See docs](https://xrpl.org/payment.html#payment-fields).

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI with new unit tests attached.