### PR TITLE
Add Helper Function for DestinationTag Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -4,6 +4,7 @@
 import Utils from '../Common/utils'
 
 import { XRPDropsAmount, Currency } from './generated/org/xrpl/rpc/v1/amount_pb'
+import { DestinationTag } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
   Memo,
@@ -35,7 +36,7 @@ interface DepositPreauthJSON {
 interface PaymentJSON {
   Amount: Record<string, unknown> | string
   Destination: string
-  DestinationTag?: number
+  DestinationTag?: DestinationTagJSON
   TransactionType: string
 }
 
@@ -77,6 +78,7 @@ interface PathElementJSON {
   currencyCode?: string
 }
 
+type DestinationTagJSON = number
 type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
@@ -177,6 +179,7 @@ const serializer = {
       return undefined
     }
 
+    // TODO(keefertaylor): Use `destinationTagToJSON` here when X-Addresses are supported in ripple-binary-codec.
     const decodedXAddress = XrpUtils.decodeXAddress(destination)
     json.Destination = decodedXAddress?.address ?? destination
     if (decodedXAddress?.tag !== undefined) {
@@ -384,6 +387,16 @@ const serializer = {
     }
 
     return undefined
+  },
+
+  /**
+   * Convert a DestinationTag to a JSON representation.
+   *
+   * @param destinationTag - The DestinationTag to convert.
+   * @returns The DestinationTag as JSON.
+   */
+  destinationTagToJSON(destinationTag: DestinationTag): DestinationTagJSON {
+    return destinationTag.getValue()
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -31,6 +31,7 @@ import {
   SetFlag,
   TransferRate,
   TickSize,
+  DestinationTag,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -888,7 +889,7 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized[0], Serializer.pathElementToJSON(pathElement1))
     assert.deepEqual(serialized[1], Serializer.pathElementToJSON(pathElement2))
   })
-    
+
   it('Serializes a Currency with a name field set', function (): void {
     // GIVEN a Currency with a name field set.
     const currencyName = 'USD'
@@ -922,5 +923,19 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized THEN the result is undefined.
     assert.isUndefined(Serializer.currencyToJSON(currency))
+  })
+
+  it('Serializes a DestinationTag', function (): void {
+    // GIVEN a DestinationTag.
+    const destinationTagValue = 123
+
+    const destinationTag = new DestinationTag()
+    destinationTag.setValue(destinationTagValue)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.destinationTagToJSON(destinationTag)
+
+    // THEN the result is the same as the input.
+    assert.equal(serialized, destinationTagValue)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Add function for `DestinationTag` serialization.

### Context of Change

Note I don't hook this up yet because we do some custom logic to parse X-Addresses. This will go away when ripple-binary-codec supports X-addresses in the next release. 

Long term I think there should be a 1:1 mapping between a protocol buffer `Foo` and a `fooToJSON` method to keep Serializer from getting too unruly.  

This refactor moves existing code into a helper method that uses this pattern. This increases readability and modularity in our code. 

`DestinationTag` docs: https://xrpl.org/payment.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

New tests provided for CI.