### PR TITLE
Add Helper Function for ClearFlag Serialization #422

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -4,6 +4,7 @@
 import Utils from '../Common/utils'
 
 import { XRPDropsAmount, Currency } from './generated/org/xrpl/rpc/v1/amount_pb'
+import { ClearFlag } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
   Memo,
@@ -16,7 +17,7 @@ import XrpUtils from './xrp-utils'
 type TransactionDataJSON = AccountSetJSON | DepositPreauthJSON | PaymentJSON
 
 interface AccountSetJSON {
-  ClearFlag?: number
+  ClearFlag?: ClearFlagJSON
   Domain?: string
   EmailHash?: string
   MessageKey?: string
@@ -77,6 +78,7 @@ interface PathElementJSON {
   currencyCode?: string
 }
 
+type ClearFlagJSON = number
 type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
@@ -242,9 +244,9 @@ const serializer = {
   accountSetToJSON(accountSet: AccountSet): AccountSetJSON | undefined {
     const json: AccountSetJSON = { TransactionType: 'AccountSet' }
 
-    const clearFlag = accountSet.getClearFlag()?.getValue()
+    const clearFlag = accountSet.getClearFlag()
     if (clearFlag !== undefined) {
-      json.ClearFlag = clearFlag
+      json.ClearFlag = this.clearFlagToJSON(clearFlag)
     }
 
     const domain = accountSet.getDomain()?.getValue()
@@ -384,6 +386,16 @@ const serializer = {
     }
 
     return undefined
+  },
+
+  /**
+   * Convert a ClearFlag to a JSON representation.
+   *
+   * @param clearFlag - The ClearFlag to convert.
+   * @returns The ClearFlag as JSON.
+   */
+  clearFlagToJSON(clearFlag: ClearFlag): ClearFlagJSON {
+    return clearFlag.getValue()
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -926,7 +926,7 @@ describe('serializer', function (): void {
   })
 
   it('Serializes a ClearFlag', function (): void {
-    // GIVEN a ClearFlag with no fields set.
+    // GIVEN a ClearFlag.
     const flagValues = 1
 
     const clearFlag = new ClearFlag()

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -4,6 +4,7 @@
  */
 
 import 'mocha'
+
 import { assert } from 'chai'
 
 import Utils from '../../src/Common/utils'
@@ -888,7 +889,7 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized[0], Serializer.pathElementToJSON(pathElement1))
     assert.deepEqual(serialized[1], Serializer.pathElementToJSON(pathElement2))
   })
-    
+
   it('Serializes a Currency with a name field set', function (): void {
     // GIVEN a Currency with a name field set.
     const currencyName = 'USD'
@@ -922,5 +923,19 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized THEN the result is undefined.
     assert.isUndefined(Serializer.currencyToJSON(currency))
+  })
+
+  it('Serializes a ClearFlag', function (): void {
+    // GIVEN a ClearFlag with no fields set.
+    const flagValues = 1
+
+    const clearFlag = new ClearFlag()
+    clearFlag.setValue(flagValues)
+
+    // WHEN it is serialized
+    const serialized = Serializer.clearFlagToJSON(clearFlag)
+
+    // THEN the result is the input.
+    assert.equal(serialized, flagValues)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Add function for `ClearFlag` serialization.

### Context of Change

Long term I think there should be a 1:1 mapping between a protocol buffer `Foo` and a `fooToJSON` method to keep Serializer from getting too unruly.  

This refactor moves existing code into a helper method that uses this pattern. This increases readability and modularity in our code. 

`ClearFlag` docs: https://xrpl.org/accountset.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

New tests provided for CI.