### PR TITLE
Add Helper Function for Domain Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -4,6 +4,7 @@
 import Utils from '../Common/utils'
 
 import { XRPDropsAmount, Currency } from './generated/org/xrpl/rpc/v1/amount_pb'
+import { Domain } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
   Memo,
@@ -17,7 +18,7 @@ type TransactionDataJSON = AccountSetJSON | DepositPreauthJSON | PaymentJSON
 
 interface AccountSetJSON {
   ClearFlag?: number
-  Domain?: string
+  Domain?: DomainJSON
   EmailHash?: string
   MessageKey?: string
   SetFlag?: number
@@ -77,6 +78,7 @@ interface PathElementJSON {
   currencyCode?: string
 }
 
+type DomainJSON = string
 type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
@@ -247,9 +249,9 @@ const serializer = {
       json.ClearFlag = clearFlag
     }
 
-    const domain = accountSet.getDomain()?.getValue()
+    const domain = accountSet.getDomain()
     if (domain !== undefined) {
-      json.Domain = domain
+      json.Domain = this.domainToJSON(domain)
     }
 
     const emailHashBytes = accountSet.getEmailHash()?.getValue_asU8()
@@ -384,6 +386,16 @@ const serializer = {
     }
 
     return undefined
+  },
+
+  /**
+   * Convert a Domain to a JSON representation.
+   *
+   * @param domain - The Domain to convert.
+   * @returns The Domain as JSON.
+   */
+  domainToJSON(domain: Domain): DomainJSON {
+    return domain.getValue()
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -888,7 +888,7 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized[0], Serializer.pathElementToJSON(pathElement1))
     assert.deepEqual(serialized[1], Serializer.pathElementToJSON(pathElement2))
   })
-    
+
   it('Serializes a Currency with a name field set', function (): void {
     // GIVEN a Currency with a name field set.
     const currencyName = 'USD'
@@ -922,5 +922,19 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized THEN the result is undefined.
     assert.isUndefined(Serializer.currencyToJSON(currency))
+  })
+
+  it('Serializes a Domain', function (): void {
+    // GIVEN a Domain
+    const domainValue = 'https://xpring.io'
+
+    const domain = new Domain()
+    domain.setValue(domainValue)
+
+    // WHEN it is serialized
+    const serialized = Serializer.domainToJSON(domain)
+
+    // THEN the result is the same as the inputs.
+    assert.equal(serialized, domainValue)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Add function for `Domain` serialization.

### Context of Change

Long term I think there should be a 1:1 mapping between a protocol buffer `Foo` and a `fooToJSON` method to keep Serializer from getting too unruly.  

This refactor moves existing code into a helper method that uses this pattern. This increases readability and modularity in our code. 

`Domain` docs: https://xrpl.org/accountset.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

New tests provided for CI.