### PR TITLE
Add Helper Function for EmailHash Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -4,6 +4,7 @@
 import Utils from '../Common/utils'
 
 import { XRPDropsAmount, Currency } from './generated/org/xrpl/rpc/v1/amount_pb'
+import { EmailHash } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
   Memo,
@@ -18,7 +19,7 @@ type TransactionDataJSON = AccountSetJSON | DepositPreauthJSON | PaymentJSON
 interface AccountSetJSON {
   ClearFlag?: number
   Domain?: string
-  EmailHash?: string
+  EmailHash?: EmailHashJSON
   MessageKey?: string
   SetFlag?: number
   TransactionType: string
@@ -77,6 +78,7 @@ interface PathElementJSON {
   currencyCode?: string
 }
 
+type EmailHashJSON = string
 type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
@@ -252,9 +254,9 @@ const serializer = {
       json.Domain = domain
     }
 
-    const emailHashBytes = accountSet.getEmailHash()?.getValue_asU8()
-    if (emailHashBytes !== undefined) {
-      json.EmailHash = Utils.toHex(emailHashBytes)
+    const emailHash = accountSet.getEmailHash()
+    if (emailHash !== undefined) {
+      json.EmailHash = this.emailHashToJSON(emailHash)
     }
 
     const messageKeyBytes = accountSet.getMessageKey()?.getValue_asU8()
@@ -384,6 +386,17 @@ const serializer = {
     }
 
     return undefined
+  },
+
+  /**
+   * Convert an EmailHash to a JSON representation.
+   *
+   * @param emailHash - The EmailHash to convert.
+   * @returns The EmailHash as JSON.
+   */
+  emailHashToJSON(emailHash: EmailHash): EmailHashJSON {
+    const emailHashBytes = emailHash.getValue_asU8()
+    return Utils.toHex(emailHashBytes)
   },
 }
 

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -406,7 +406,7 @@ const serializer = {
   emailHashToJSON(emailHash: EmailHash): EmailHashJSON {
     const emailHashBytes = emailHash.getValue_asU8()
     return Utils.toHex(emailHashBytes)
-  } 
+  },
    
   /**
    * Convert a DestinationTag to a JSON representation.

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -888,7 +888,7 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized[0], Serializer.pathElementToJSON(pathElement1))
     assert.deepEqual(serialized[1], Serializer.pathElementToJSON(pathElement2))
   })
-    
+
   it('Serializes a Currency with a name field set', function (): void {
     // GIVEN a Currency with a name field set.
     const currencyName = 'USD'
@@ -922,5 +922,19 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized THEN the result is undefined.
     assert.isUndefined(Serializer.currencyToJSON(currency))
+  })
+
+  it('Serializes an EmailHash', function (): void {
+    // GIVEN an EmailHash.
+    const emailHashBytes = new Uint8Array([1, 2, 3, 4])
+
+    const emailHash = new EmailHash()
+    emailHash.setValue(emailHashBytes)
+
+    // WHEN it is serialized
+    const serialized = Serializer.emailHashToJSON(emailHash)
+
+    // THEN the result is the same as the input bytes encoded to hex.
+    assert.deepEqual(serialized, Utils.toHex(emailHashBytes))
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Add function for `EmailHash` serialization.

### Context of Change

Long term I think there should be a 1:1 mapping between a protocol buffer `Foo` and a `fooToJSON` method to keep Serializer from getting too unruly.  

This refactor moves existing code into a helper method that uses this pattern. This increases readability and modularity in our code. 

`EmailHash` docs: https://xrpl.org/accountset.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

New tests provided for CI.