### PR TITLE
Add Helper Function for MessageKey Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -4,6 +4,7 @@
 import Utils from '../Common/utils'
 
 import { XRPDropsAmount, Currency } from './generated/org/xrpl/rpc/v1/amount_pb'
+import { MessageKey } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
   Memo,
@@ -19,7 +20,7 @@ interface AccountSetJSON {
   ClearFlag?: number
   Domain?: string
   EmailHash?: string
-  MessageKey?: string
+  MessageKey?: MessageKeyJSON
   SetFlag?: number
   TransactionType: string
   TransferRate?: number
@@ -77,6 +78,7 @@ interface PathElementJSON {
   currencyCode?: string
 }
 
+type MessageKeyJSON = string
 type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
@@ -257,9 +259,9 @@ const serializer = {
       json.EmailHash = Utils.toHex(emailHashBytes)
     }
 
-    const messageKeyBytes = accountSet.getMessageKey()?.getValue_asU8()
-    if (messageKeyBytes !== undefined) {
-      json.MessageKey = Utils.toHex(messageKeyBytes)
+    const messageKey = accountSet.getMessageKey()
+    if (messageKey !== undefined) {
+      json.MessageKey = this.messageKeyToJSON(messageKey)
     }
 
     const setFlag = accountSet.getSetFlag()?.getValue()
@@ -384,6 +386,17 @@ const serializer = {
     }
 
     return undefined
+  },
+
+  /**
+   * Convert a MessageKey to a JSON representation.
+   *
+   * @param messageKey - The MessageKey to convert.
+   * @returns The MessageKey as JSON.
+   */
+  messageKeyToJSON(messageKey: MessageKey): MessageKeyJSON {
+    const messageKeyBytes = messageKey.getValue_asU8()
+    return Utils.toHex(messageKeyBytes)
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -888,7 +888,7 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized[0], Serializer.pathElementToJSON(pathElement1))
     assert.deepEqual(serialized[1], Serializer.pathElementToJSON(pathElement2))
   })
-    
+
   it('Serializes a Currency with a name field set', function (): void {
     // GIVEN a Currency with a name field set.
     const currencyName = 'USD'
@@ -922,5 +922,19 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized THEN the result is undefined.
     assert.isUndefined(Serializer.currencyToJSON(currency))
+  })
+
+  it('Serializes a MessageKey', function (): void {
+    // GIVEN a MessageKey.
+    const messageKeyBytes = new Uint8Array([1, 2, 3, 4])
+
+    const messageKey = new MessageKey()
+    messageKey.setValue(messageKeyBytes)
+
+    // WHEN it is serialized
+    const serialized = Serializer.messageKeyToJSON(messageKey)
+
+    // THEN the result is the same as the input bytes encoded to hex.
+    assert.deepEqual(serialized, Utils.toHex(messageKeyBytes))
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Add function for `MessageKey` serialization.

### Context of Change

Long term I think there should be a 1:1 mapping between a protocol buffer `Foo` and a `fooToJSON` method to keep Serializer from getting too unruly.  

This refactor moves existing code into a helper method that uses this pattern. This increases readability and modularity in our code. 

`MessageKey` docs: https://xrpl.org/accountset.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

New tests provided for CI.