### PR TITLE
Add Helper Function for SetFlag Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -4,6 +4,7 @@
 import Utils from '../Common/utils'
 
 import { XRPDropsAmount, Currency } from './generated/org/xrpl/rpc/v1/amount_pb'
+import { SetFlag } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
   Memo,
@@ -20,7 +21,7 @@ interface AccountSetJSON {
   Domain?: string
   EmailHash?: string
   MessageKey?: string
-  SetFlag?: number
+  SetFlag?: SetFlagJSON
   TransactionType: string
   TransferRate?: number
   TickSize?: number
@@ -77,6 +78,7 @@ interface PathElementJSON {
   currencyCode?: string
 }
 
+type SetFlagJSON = number
 type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
@@ -262,9 +264,9 @@ const serializer = {
       json.MessageKey = Utils.toHex(messageKeyBytes)
     }
 
-    const setFlag = accountSet.getSetFlag()?.getValue()
+    const setFlag = accountSet.getSetFlag()
     if (setFlag !== undefined) {
-      json.SetFlag = setFlag
+      json.SetFlag = this.setFlagToJSON(setFlag)
     }
 
     const transferRate = accountSet.getTransferRate()?.getValue()
@@ -384,6 +386,16 @@ const serializer = {
     }
 
     return undefined
+  },
+
+  /**
+   * Convert a SetFlag to a JSON representation.
+   *
+   * @param setFlag - The SetFlag to convert.
+   * @returns The SetFlag as JSON.
+   */
+  setFlagToJSON(setFlag: SetFlag): SetFlagJSON {
+    return setFlag.getValue()
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -888,7 +888,7 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized[0], Serializer.pathElementToJSON(pathElement1))
     assert.deepEqual(serialized[1], Serializer.pathElementToJSON(pathElement2))
   })
-    
+
   it('Serializes a Currency with a name field set', function (): void {
     // GIVEN a Currency with a name field set.
     const currencyName = 'USD'
@@ -922,5 +922,19 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized THEN the result is undefined.
     assert.isUndefined(Serializer.currencyToJSON(currency))
+  })
+
+  it('Serializes a SetFlag', function (): void {
+    // GIVEN a SetFlag.
+    const setFlagValue = 1
+
+    const setFlag = new SetFlag()
+    setFlag.setValue(setFlagValue)
+
+    // WHEN it is serialized
+    const serialized = Serializer.setFlagToJSON(setFlag)
+
+    // THEN the result is the same as the input.
+    assert.deepEqual(serialized, setFlagValue)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Add function for `SetFlag` serialization.

### Context of Change

Long term I think there should be a 1:1 mapping between a protocol buffer `Foo` and a `fooToJSON` method to keep Serializer from getting too unruly.  

This refactor moves existing code into a helper method that uses this pattern. This increases readability and modularity in our code. 

`SetFlag` docs: https://xrpl.org/accountset.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

New tests provided for CI.