### PR TITLE
Add Helper Function for Sequence Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -173,6 +173,7 @@ const serializer = {
     const sequence = transaction.getSequence()
     object.Sequence = sequence !== undefined ? this.sequenceToJSON(sequence) : 0
 
+    const lastLedgerSequence = transaction.getLastLedgerSequence()
     object.LastLedgerSequence =
       lastLedgerSequence !== undefined
         ? this.lastLedgerSequenceToJSON(lastLedgerSequence)
@@ -475,7 +476,7 @@ const serializer = {
   sequenceToJSON(sequence: Sequence): SequenceJSON {
     return sequence.getValue()
   },
-    
+
   /**
    * Convert a LastLedgerSequence to a JSON representation.
    *
@@ -487,7 +488,7 @@ const serializer = {
   ): LastLedgerSequenceJSON {
     return lastLedgerSequence.getValue()
   },
-  
+
   /**
    * Convert a ClearFlag to a JSON representation.
    *
@@ -497,7 +498,7 @@ const serializer = {
   clearFlagToJSON(clearFlag: ClearFlag): ClearFlagJSON {
     return clearFlag.getValue()
   },
-    
+
   /**
    * Convert an EmailHash to a JSON representation.
    *

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -4,6 +4,7 @@
 import Utils from '../Common/utils'
 
 import { XRPDropsAmount, Currency } from './generated/org/xrpl/rpc/v1/amount_pb'
+import { Sequence } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
   Memo,
@@ -53,7 +54,7 @@ interface BaseTransactionJSON {
   Account: string
   Fee: string
   LastLedgerSequence: number
-  Sequence: number
+  Sequence: SequenceJSON
   SigningPubKey: string
   TxnSignature?: string
   Memos?: MemoJSON[]
@@ -77,6 +78,7 @@ interface PathElementJSON {
   currencyCode?: string
 }
 
+type SequenceJSON = number
 type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
@@ -384,6 +386,16 @@ const serializer = {
     }
 
     return undefined
+  },
+
+  /**
+   * Convert a Sequence to a JSON representation.
+   *
+   * @param sequence - The Sequence to convert.
+   * @returns The Sequence as JSON.
+   */
+  sequenceToJSON(sequence: Sequence): SequenceJSON {
+    return sequence.getValue()
   },
 }
 

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -133,7 +133,9 @@ const serializer = {
     object.Fee = this.xrpAmountToJSON(txFee)
 
     // Set sequence numbers
-    object.Sequence = transaction.getSequence()?.getValue() ?? 0
+    const sequence = transaction.getSequence()
+    object.Sequence = sequence !== undefined ? this.sequenceToJSON(sequence) : 0
+
     object.LastLedgerSequence =
       transaction.getLastLedgerSequence()?.getValue() ?? 0
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -50,7 +50,7 @@ const destinationXAddressWithoutTag =
 const destinationXAddressWithTag =
   'XVPcpSm47b1CZkf5AkKM9a84dQHe3mTAxgxfLw2qYoe7Boa'
 const tag = 12345
-const sequence = 1
+const sequenceValue = 1
 const lastLedgerSequence = 20
 const publicKey =
   '031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE'
@@ -393,7 +393,7 @@ describe('serializer', function (): void {
       destinationClassicAddress,
       fee,
       lastLedgerSequence,
-      sequence,
+      sequenceValue,
       accountClassicAddress,
       publicKey,
     )
@@ -408,7 +408,7 @@ describe('serializer', function (): void {
       Destination: destinationClassicAddress,
       Fee: fee.toString(),
       LastLedgerSequence: lastLedgerSequence,
-      Sequence: sequence,
+      Sequence: sequenceValue,
       TransactionType: 'Payment',
       SigningPubKey: publicKey,
     }
@@ -422,7 +422,7 @@ describe('serializer', function (): void {
       destinationClassicAddress,
       fee,
       lastLedgerSequence,
-      sequence,
+      sequenceValue,
       accountXAddress,
       publicKey,
     )
@@ -437,7 +437,7 @@ describe('serializer', function (): void {
       Destination: destinationClassicAddress,
       Fee: fee.toString(),
       LastLedgerSequence: lastLedgerSequence,
-      Sequence: sequence,
+      Sequence: sequenceValue,
       TransactionType: 'Payment',
       SigningPubKey: publicKey,
     }
@@ -452,7 +452,7 @@ describe('serializer', function (): void {
       destinationClassicAddress,
       fee,
       lastLedgerSequence,
-      sequence,
+      sequenceValue,
       account,
       publicKey,
     )
@@ -471,7 +471,7 @@ describe('serializer', function (): void {
       destinationClassicAddress,
       fee,
       lastLedgerSequence,
-      sequence,
+      sequenceValue,
       undefined,
       publicKey,
     )
@@ -490,7 +490,7 @@ describe('serializer', function (): void {
       destinationXAddressWithTag,
       fee,
       lastLedgerSequence,
-      sequence,
+      sequenceValue,
       accountClassicAddress,
       publicKey,
     )
@@ -506,7 +506,7 @@ describe('serializer', function (): void {
       DestinationTag: tag,
       Fee: fee.toString(),
       LastLedgerSequence: lastLedgerSequence,
-      Sequence: sequence,
+      Sequence: sequenceValue,
       TransactionType: 'Payment',
       SigningPubKey: publicKey,
     }
@@ -520,7 +520,7 @@ describe('serializer', function (): void {
       destinationXAddressWithoutTag,
       fee,
       lastLedgerSequence,
-      sequence,
+      sequenceValue,
       accountClassicAddress,
       publicKey,
     )
@@ -535,7 +535,7 @@ describe('serializer', function (): void {
       Destination: destinationClassicAddress,
       Fee: fee.toString(),
       LastLedgerSequence: lastLedgerSequence,
-      Sequence: sequence,
+      Sequence: sequenceValue,
       TransactionType: 'Payment',
       SigningPubKey: publicKey,
     }
@@ -550,7 +550,7 @@ describe('serializer', function (): void {
       destinationXAddressWithoutTag,
       fee,
       lastLedgerSequence,
-      sequence,
+      sequenceValue,
       accountClassicAddress,
       publicKey,
     )
@@ -578,7 +578,7 @@ describe('serializer', function (): void {
       Destination: destinationClassicAddress,
       Fee: fee.toString(),
       LastLedgerSequence: lastLedgerSequence,
-      Sequence: sequence,
+      Sequence: sequenceValue,
       TransactionType: 'Payment',
       SigningPubKey: publicKey,
       Memos: [
@@ -702,7 +702,7 @@ describe('serializer', function (): void {
       undefined,
       fee,
       lastLedgerSequence,
-      sequence,
+      sequenceValue,
       accountClassicAddress,
       publicKey,
     )
@@ -719,7 +719,7 @@ describe('serializer', function (): void {
       undefined,
       fee,
       lastLedgerSequence,
-      sequence,
+      sequenceValue,
       accountClassicAddress,
       publicKey,
     )
@@ -802,7 +802,7 @@ describe('serializer', function (): void {
       undefined,
       fee,
       lastLedgerSequence,
-      sequence,
+      sequenceValue,
       accountClassicAddress,
       publicKey,
     )
@@ -888,7 +888,7 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized[0], Serializer.pathElementToJSON(pathElement1))
     assert.deepEqual(serialized[1], Serializer.pathElementToJSON(pathElement2))
   })
-    
+
   it('Serializes a Currency with a name field set', function (): void {
     // GIVEN a Currency with a name field set.
     const currencyName = 'USD'
@@ -922,5 +922,17 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized THEN the result is undefined.
     assert.isUndefined(Serializer.currencyToJSON(currency))
+  })
+
+  it('Serializes a Sequence', function (): void {
+    // GIVEN a Sequence.
+    const sequence = new Sequence()
+    sequence.setValue(sequenceValue)
+
+    // WHEN it is serialized
+    const serialized = Serializer.sequenceToJSON(sequence)
+
+    // THEN the result is the same as the input.
+    assert.deepEqual(serialized, sequenceValue)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1040,7 +1040,7 @@ describe('serializer', function (): void {
     // THEN the result is the same as the input.
     assert.deepEqual(serialized, sequenceValue)
   })
- 
+
   it('Serializes a LastLedgerSequence', function (): void {
     // GIVEN a LastLedgerSequence.
     const lastLedgerSequence = new LastLedgerSequence()
@@ -1066,7 +1066,7 @@ describe('serializer', function (): void {
     // THEN the result is the input.
     assert.equal(serialized, flagValues)
   })
-    
+
   it('Serializes an EmailHash', function (): void {
     // GIVEN an EmailHash.
     const emailHashBytes = new Uint8Array([1, 2, 3, 4])


### PR DESCRIPTION
## High Level Overview of Change

Add function for `Sequence` serialization.

### Context of Change

Long term I think there should be a 1:1 mapping between a protocol buffer `Foo` and a `fooToJSON` method to keep Serializer from getting too unruly.  

This refactor moves existing code into a helper method that uses this pattern. This increases readability and modularity in our code. 

`Sequence` docs: https://xrpl.org/transaction-common-fields.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

New tests provided for CI.