### PR TITLE
Add Helper Function for LastLedgerSequence Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -15,7 +15,7 @@ import {
   Domain,
   EmailHash,
   InvoiceID,
-  LastLedgerSequence  
+  LastLedgerSequence,
   MessageKey,
   SetFlag,
   TransferRate,

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -4,6 +4,7 @@
 import Utils from '../Common/utils'
 
 import { XRPDropsAmount, Currency } from './generated/org/xrpl/rpc/v1/amount_pb'
+import { LastLedgerSequence } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
   Memo,
@@ -52,7 +53,7 @@ interface MemoDetailsJSON {
 interface BaseTransactionJSON {
   Account: string
   Fee: string
-  LastLedgerSequence: number
+  LastLedgerSequence: LastLedgerSequenceJSON
   Sequence: number
   SigningPubKey: string
   TxnSignature?: string
@@ -77,6 +78,7 @@ interface PathElementJSON {
   currencyCode?: string
 }
 
+type LastLedgerSequenceJSON = number
 type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSONAddition
@@ -132,8 +134,12 @@ const serializer = {
 
     // Set sequence numbers
     object.Sequence = transaction.getSequence()?.getValue() ?? 0
+
+    const lastLedgerSequence = transaction.getLastLedgerSequence()
     object.LastLedgerSequence =
-      transaction.getLastLedgerSequence()?.getValue() ?? 0
+      lastLedgerSequence !== undefined
+        ? this.lastLedgerSequenceToJSON(lastLedgerSequence)
+        : 0
 
     const signingPubKeyBytes = transaction
       .getSigningPublicKey()
@@ -384,6 +390,18 @@ const serializer = {
     }
 
     return undefined
+  },
+
+  /**
+   * Convert a LastLedgerSequence to a JSON representation.
+   *
+   * @param lastLedgerSequence - The LastLedgerSequence to convert.
+   * @returns The LastLedgerSequence as JSON.
+   */
+  lastLedgerSequenceToJSON(
+    lastLedgerSequence: LastLedgerSequence,
+  ): LastLedgerSequenceJSON {
+    return lastLedgerSequence.getValue()
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -31,6 +31,7 @@ import {
   SetFlag,
   TransferRate,
   TickSize,
+  LastLedgerSequence,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -51,7 +52,7 @@ const destinationXAddressWithTag =
   'XVPcpSm47b1CZkf5AkKM9a84dQHe3mTAxgxfLw2qYoe7Boa'
 const tag = 12345
 const sequence = 1
-const lastLedgerSequence = 20
+const lastLedgerSequenceValue = 20
 const publicKey =
   '031D68BC1A142E6766B2BDFB006CCFE135EF2E0E2E94ABB5CF5C9AB6104776FBAE'
 const fee = '10'
@@ -392,7 +393,7 @@ describe('serializer', function (): void {
       value,
       destinationClassicAddress,
       fee,
-      lastLedgerSequence,
+      lastLedgerSequenceValue,
       sequence,
       accountClassicAddress,
       publicKey,
@@ -407,7 +408,7 @@ describe('serializer', function (): void {
       Amount: value.toString(),
       Destination: destinationClassicAddress,
       Fee: fee.toString(),
-      LastLedgerSequence: lastLedgerSequence,
+      LastLedgerSequence: lastLedgerSequenceValue,
       Sequence: sequence,
       TransactionType: 'Payment',
       SigningPubKey: publicKey,
@@ -421,7 +422,7 @@ describe('serializer', function (): void {
       value,
       destinationClassicAddress,
       fee,
-      lastLedgerSequence,
+      lastLedgerSequenceValue,
       sequence,
       accountXAddress,
       publicKey,
@@ -436,7 +437,7 @@ describe('serializer', function (): void {
       Amount: value.toString(),
       Destination: destinationClassicAddress,
       Fee: fee.toString(),
-      LastLedgerSequence: lastLedgerSequence,
+      LastLedgerSequence: lastLedgerSequenceValue,
       Sequence: sequence,
       TransactionType: 'Payment',
       SigningPubKey: publicKey,
@@ -451,7 +452,7 @@ describe('serializer', function (): void {
       value,
       destinationClassicAddress,
       fee,
-      lastLedgerSequence,
+      lastLedgerSequenceValue,
       sequence,
       account,
       publicKey,
@@ -470,7 +471,7 @@ describe('serializer', function (): void {
       value,
       destinationClassicAddress,
       fee,
-      lastLedgerSequence,
+      lastLedgerSequenceValue,
       sequence,
       undefined,
       publicKey,
@@ -489,7 +490,7 @@ describe('serializer', function (): void {
       value,
       destinationXAddressWithTag,
       fee,
-      lastLedgerSequence,
+      lastLedgerSequenceValue,
       sequence,
       accountClassicAddress,
       publicKey,
@@ -505,7 +506,7 @@ describe('serializer', function (): void {
       Destination: destinationClassicAddress,
       DestinationTag: tag,
       Fee: fee.toString(),
-      LastLedgerSequence: lastLedgerSequence,
+      LastLedgerSequence: lastLedgerSequenceValue,
       Sequence: sequence,
       TransactionType: 'Payment',
       SigningPubKey: publicKey,
@@ -519,7 +520,7 @@ describe('serializer', function (): void {
       value,
       destinationXAddressWithoutTag,
       fee,
-      lastLedgerSequence,
+      lastLedgerSequenceValue,
       sequence,
       accountClassicAddress,
       publicKey,
@@ -534,7 +535,7 @@ describe('serializer', function (): void {
       Amount: value.toString(),
       Destination: destinationClassicAddress,
       Fee: fee.toString(),
-      LastLedgerSequence: lastLedgerSequence,
+      LastLedgerSequence: lastLedgerSequenceValue,
       Sequence: sequence,
       TransactionType: 'Payment',
       SigningPubKey: publicKey,
@@ -549,7 +550,7 @@ describe('serializer', function (): void {
       value,
       destinationXAddressWithoutTag,
       fee,
-      lastLedgerSequence,
+      lastLedgerSequenceValue,
       sequence,
       accountClassicAddress,
       publicKey,
@@ -577,7 +578,7 @@ describe('serializer', function (): void {
       Amount: value.toString(),
       Destination: destinationClassicAddress,
       Fee: fee.toString(),
-      LastLedgerSequence: lastLedgerSequence,
+      LastLedgerSequence: lastLedgerSequenceValue,
       Sequence: sequence,
       TransactionType: 'Payment',
       SigningPubKey: publicKey,
@@ -701,7 +702,7 @@ describe('serializer', function (): void {
       address,
       undefined,
       fee,
-      lastLedgerSequence,
+      lastLedgerSequenceValue,
       sequence,
       accountClassicAddress,
       publicKey,
@@ -718,7 +719,7 @@ describe('serializer', function (): void {
       undefined,
       undefined,
       fee,
-      lastLedgerSequence,
+      lastLedgerSequenceValue,
       sequence,
       accountClassicAddress,
       publicKey,
@@ -801,7 +802,7 @@ describe('serializer', function (): void {
       undefined,
       undefined,
       fee,
-      lastLedgerSequence,
+      lastLedgerSequenceValue,
       sequence,
       accountClassicAddress,
       publicKey,
@@ -888,7 +889,7 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized[0], Serializer.pathElementToJSON(pathElement1))
     assert.deepEqual(serialized[1], Serializer.pathElementToJSON(pathElement2))
   })
-    
+
   it('Serializes a Currency with a name field set', function (): void {
     // GIVEN a Currency with a name field set.
     const currencyName = 'USD'
@@ -922,5 +923,17 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized THEN the result is undefined.
     assert.isUndefined(Serializer.currencyToJSON(currency))
+  })
+
+  it('Serializes a LastLedgerSequence', function (): void {
+    // GIVEN a LastLedgerSequence.
+    const lastLedgerSequence = new LastLedgerSequence()
+    lastLedgerSequence.setValue(lastLedgerSequenceValue)
+
+    // WHEN it is serialized
+    const serialized = Serializer.lastLedgerSequenceToJSON(lastLedgerSequence)
+
+    // THEN the result is the same as the input.
+    assert.deepEqual(serialized, lastLedgerSequenceValue)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Add function for `LastLedgerSequence` serialization.

### Context of Change

Long term I think there should be a 1:1 mapping between a protocol buffer `Foo` and a `fooToJSON` method to keep Serializer from getting too unruly.  

This refactor moves existing code into a helper method that uses this pattern. This increases readability and modularity in our code. 

`LastLedgerSequence` docs: https://xrpl.org/transaction-common-fields.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

New tests provided for CI.