### PR TITLE
Add Serialization for Amount Protobufs

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -8,6 +8,7 @@ import {
   XRPDropsAmount,
   Currency,
   IssuedCurrencyAmount,
+  CurrencyAmount,
 } from './generated/org/xrpl/rpc/v1/amount_pb'
 import {
   Authorize,
@@ -20,6 +21,7 @@ import {
   SetFlag,
   TransferRate,
   TickSize,
+  Amount,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -100,6 +102,7 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type AmountJSON = CurrencyAmountJSON
 type ClearFlagJSON = number
 type EmailHashJSON = string
 type SetFlagJSON = number
@@ -461,7 +464,7 @@ const serializer = {
   clearFlagToJSON(clearFlag: ClearFlag): ClearFlagJSON {
     return clearFlag.getValue()
   },
-    
+
   /**
    * Convert an EmailHash to a JSON representation.
    *
@@ -472,7 +475,7 @@ const serializer = {
     const emailHashBytes = emailHash.getValue_asU8()
     return Utils.toHex(emailHashBytes)
   },
-   
+
   /**
    * Convert a SetFlag to a JSON representation.
    *
@@ -557,6 +560,21 @@ const serializer = {
    */
   invoiceIdToJSON(invoiceId: InvoiceID): InvoiceIdJSON {
     return Utils.toHex(invoiceId.getValue_asU8())
+  },
+
+  /**
+ * Convert an Amount to a JSON representation.
+ *
+ * @param amount - The Amount to convert.
+ * @returns The Amount as JSON.
+ */
+  amountToJSON(amount: Amount): AmountJSON | undefined {
+    const currencyAmount = amount.getValue()
+    if (currencyAmount === undefined) {
+      return undefined
+    }
+
+    return this.currencyAmount(currencyAmount)
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1247,17 +1247,6 @@ describe('serializer', function (): void {
     assert.equal(serialized, Serializer.currencyAmountToJSON(currencyAmount))
   })
 
-  it('Fails to serialize a malformed CurrencyAmount', function (): void {
-    // GIVEN an Amount with no value.
-    const amount = new Amount()
-
-    // WHEN it is serialized.
-    const serialized = Serializer.amountToJSON(amount)
-
-    // THEN the result is undefined.
-    assert.isUndefined(serialized)
-  })
-    
   it('Serializes a MemoData', function (): void {
     // GIVEN a MemoData with some bytes
     const memoDataBytes = new Uint8Array([0, 1, 2, 3])

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1235,7 +1235,7 @@ describe('serializer', function (): void {
     assert.equal(serialized, Serializer.currencyAmountToJSON(currencyAmount))
   })
 
-  it('Failes to serialize a malformed CurrencyAmount', function (): void {
+  it('Fails to serialize a malformed CurrencyAmount', function (): void {
     // GIVEN an Amount with no value.
     const amount = new Amount()
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1217,7 +1217,7 @@ describe('serializer', function (): void {
     assert.isUndefined(serialized)
   })
 
-  it('Serializes an Amount with an CurencyAmount', function (): void {
+  it('Serializes an Amount with a CurrencyAmount', function (): void {
     // GIVEN an Amount wrapping a CurrencyAmount.
     const dropsValue = '123'
     const xrpDropsAmount = makeXrpDropsAmount(dropsValue)


### PR DESCRIPTION
## High Level Overview of Change

Add serialization for Amount objects. 

### Context of Change

This PR continues to serialize intermediary objects. `Amount` is just a wrapper for `CurrencyAmount`


### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI with new tests provided