### PR TITLE
Refactor Memo Serialization for Consistency 

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -435,9 +435,7 @@ const serializer = {
    * @returns The MemoData as JSON.
    */
   memoDataToJSON(memoData: MemoData): MemoDataJSON | undefined {
-    return memoData.getValue_asU8().length > 0
-      ? memoData.getValue_asU8()
-      : undefined
+    return memoData.getValue_asU8()
   },
 
   /**

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -21,6 +21,7 @@ import {
   SetFlag,
   TransferRate,
   TickSize,
+  MemoData,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -62,9 +63,9 @@ interface MemoJSON {
 }
 
 interface MemoDetailsJSON {
-  MemoData?: Uint8Array
-  MemoType?: Uint8Array
-  MemoFormat?: Uint8Array
+  MemoData?: MemoDataJSON
+  MemoType?: MemoDataJSON
+  MemoFormat?: MemoDataJSON
 }
 
 interface BaseTransactionJSON {
@@ -101,6 +102,7 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type MemoDataJSON = Uint8Array
 type LastLedgerSequenceJSON = number
 type XRPDropsAmountJSON = string
 type CurrencyAmountJSON = IssuedCurrencyAmountJSON | XRPDropsAmountJSON
@@ -403,15 +405,39 @@ const serializer = {
    * @returns The Memo as JSON.
    */
   memoToJSON(memo: Memo): MemoJSON {
-    const jsonMemo: MemoDetailsJSON = {
-      MemoData: memo.getMemoData()?.getValue_asU8(),
-      MemoFormat: memo.getMemoFormat()?.getValue_asU8(),
-      MemoType: memo.getMemoType()?.getValue_asU8(),
+    const memoData = memo.getMemoData()
+    const memoFormat = memo.getMemoFormat()
+    const memoType = memo.getMemoType()
+
+    const jsonMemo: MemoDetailsJSON = {}
+
+    if (memoData !== undefined) {
+      jsonMemo.MemoData = this.memoDataToJSON(memoData)
+    }
+
+    if (memoFormat !== undefined) {
+      jsonMemo.MemoFormat = this.memoDataToJSON(memoFormat)
+    }
+
+    if (memoType !== undefined) {
+      jsonMemo.MemoType = this.memoDataToJSON(memoType)
     }
 
     return {
       Memo: jsonMemo,
     }
+  },
+
+  /**
+   * Convert a MemoData to a JSON representation.
+   *
+   * @param memoData - The MemoData to convert.
+   * @returns The MemoData as JSON.
+   */
+  memoDataToJSON(memoData: MemoData): MemoDataJSON | undefined {
+    return memoData.getValue_asU8().length > 0
+      ? memoData.getValue_asU8()
+      : undefined
   },
 
   /**
@@ -475,7 +501,7 @@ const serializer = {
   ): LastLedgerSequenceJSON {
     return lastLedgerSequence.getValue()
   },
-  
+
   /**
    * Convert a ClearFlag to a JSON representation.
    *
@@ -485,7 +511,7 @@ const serializer = {
   clearFlagToJSON(clearFlag: ClearFlag): ClearFlagJSON {
     return clearFlag.getValue()
   },
-    
+
   /**
    * Convert an EmailHash to a JSON representation.
    *

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -22,6 +22,8 @@ import {
   TransferRate,
   TickSize,
   MemoData,
+  MemoFormat,
+  MemoType,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -64,8 +66,8 @@ interface MemoJSON {
 
 interface MemoDetailsJSON {
   MemoData?: MemoDataJSON
-  MemoType?: MemoDataJSON
-  MemoFormat?: MemoDataJSON
+  MemoType?: MemoTypeJSON
+  MemoFormat?: MemoFormatJSON
 }
 
 interface BaseTransactionJSON {
@@ -102,7 +104,9 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
-type MemoDataJSON = Uint8Array
+type MemoDataJSON = string
+type MemoTypeJSON = string
+type MemoFormatJSON = string
 type LastLedgerSequenceJSON = number
 type XRPDropsAmountJSON = string
 type CurrencyAmountJSON = IssuedCurrencyAmountJSON | XRPDropsAmountJSON
@@ -409,18 +413,22 @@ const serializer = {
     const memoFormat = memo.getMemoFormat()
     const memoType = memo.getMemoType()
 
-    const jsonMemo: MemoDetailsJSON = {}
+    const jsonMemo: MemoDetailsJSON = {
+      MemoData: undefined,
+      MemoFormat: undefined,
+      MemoType: undefined,
+    }
 
     if (memoData !== undefined) {
       jsonMemo.MemoData = this.memoDataToJSON(memoData)
     }
 
     if (memoFormat !== undefined) {
-      jsonMemo.MemoFormat = this.memoDataToJSON(memoFormat)
+      jsonMemo.MemoFormat = this.memoFormatToJSON(memoFormat)
     }
 
     if (memoType !== undefined) {
-      jsonMemo.MemoType = this.memoDataToJSON(memoType)
+      jsonMemo.MemoType = this.memoTypeToJSON(memoType)
     }
 
     return {
@@ -434,8 +442,28 @@ const serializer = {
    * @param memoData - The MemoData to convert.
    * @returns The MemoData as JSON.
    */
-  memoDataToJSON(memoData: MemoData): MemoDataJSON | undefined {
-    return memoData.getValue_asU8()
+  memoDataToJSON(memoData: MemoData): MemoDataJSON {
+    return Utils.toHex(memoData.getValue_asU8())
+  },
+
+  /**
+   * Convert a MemoFormat to a JSON representation.
+   *
+   * @param memoFormat - The MemoFormat to convert.
+   * @returns The MemoFormat as JSON.
+   */
+  memoFormatToJSON(memoFormat: MemoFormat): MemoFormatJSON {
+    return Utils.toHex(memoFormat.getValue_asU8())
+  },
+
+  /**
+   * Convert a MemoType to a JSON representation.
+   *
+   * @param memoType - The MemoType to convert.
+   * @returns The MemoType as JSON.
+   */
+  memoTypeToJSON(memoType: MemoType): MemoTypeJSON {
+    return Utils.toHex(memoType.getValue_asU8())
   },
 
   /**

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1054,7 +1054,7 @@ describe('serializer', function (): void {
     // THEN the result is the input.
     assert.equal(serialized, flagValues)
   })
-    
+
   it('Serializes an EmailHash', function (): void {
     // GIVEN an EmailHash.
     const emailHashBytes = new Uint8Array([1, 2, 3, 4])

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -623,9 +623,9 @@ describe('serializer', function (): void {
       Memos: [
         {
           Memo: {
-            MemoData: dataForMemo,
-            MemoType: typeForMemo,
-            MemoFormat: formatForMemo,
+            MemoData: Utils.toHex(dataForMemo),
+            MemoType: Utils.toHex(typeForMemo),
+            MemoFormat: Utils.toHex(formatForMemo),
           },
         },
       ],
@@ -651,9 +651,9 @@ describe('serializer', function (): void {
 
     const expectedJSON = {
       Memo: {
-        MemoData: dataForMemo,
-        MemoType: typeForMemo,
-        MemoFormat: formatForMemo,
+        MemoData: Utils.toHex(dataForMemo),
+        MemoType: Utils.toHex(typeForMemo),
+        MemoFormat: Utils.toHex(formatForMemo),
       },
     }
 
@@ -1215,5 +1215,47 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)
+  })
+
+  it('Serializes an MemoData', function (): void {
+    // GIVEN a MemoData with some bytes
+    const memoDataBytes = new Uint8Array([0, 1, 2, 3])
+
+    const memoData = new MemoData()
+    memoData.setValue(memoDataBytes)
+
+    // WHEN it is serialized
+    const serialized = Serializer.memoDataToJSON(memoData)
+
+    // THEN the result is the hex representation of the bytes.
+    assert.equal(serialized, Utils.toHex(memoDataBytes))
+  })
+
+  it('Serializes an MemoType', function (): void {
+    // GIVEN a MemoType with some bytes
+    const memoTypeBytes = new Uint8Array([0, 1, 2, 3])
+
+    const memoType = new MemoType()
+    memoType.setValue(memoTypeBytes)
+
+    // WHEN it is serialized
+    const serialized = Serializer.memoDataToJSON(memoType)
+
+    // THEN the result is the hex representation of the bytes.
+    assert.equal(serialized, Utils.toHex(memoTypeBytes))
+  })
+
+  it('Serializes an MemoFormat', function (): void {
+    // GIVEN a MemoFormat with some bytes
+    const memoFormatBytes = new Uint8Array([0, 1, 2, 3])
+
+    const memoFormat = new MemoFormat()
+    memoFormat.setValue(memoFormatBytes)
+
+    // WHEN it is serialized
+    const serialized = Serializer.memoDataToJSON(memoFormat)
+
+    // THEN the result is the hex representation of the bytes.
+    assert.equal(serialized, Utils.toHex(memoFormatBytes))
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1229,7 +1229,7 @@ describe('serializer', function (): void {
     assert.isUndefined(serialized)
   })
 
-  it('Serializes an MemoData', function (): void {
+  it('Serializes a MemoData', function (): void {
     // GIVEN a MemoData with some bytes
     const memoDataBytes = new Uint8Array([0, 1, 2, 3])
 


### PR DESCRIPTION
## High Level Overview of Change

Refactor Memo serialization to use tested helper functions.

### Context of Change

This minor refactor keeps things consistent. 

Note that we can represent bytes as either hex encoded `string`s or `UInt8Array`s. This migrates memos to use the former for consistency with the way we handle other byte fields in `Serializer`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A 

## Test Plan

Updated  existing tests for `string` vs `UInt8Array` differences, tested new methods. 