### PR TITLE
Refactor Types for Transaction types

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -21,6 +21,7 @@ import {
   SetFlag,
   TransferRate,
   TickSize,
+  MemoData,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -62,9 +63,9 @@ interface MemoJSON {
 }
 
 interface MemoDetailsJSON {
-  MemoData?: Uint8Array
-  MemoType?: Uint8Array
-  MemoFormat?: Uint8Array
+  MemoData?: MemoDataJSON
+  MemoType?: MemoDataJSON
+  MemoFormat?: MemoDataJSON
 }
 
 interface BaseTransactionJSON {
@@ -101,6 +102,7 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type MemoDataJSON = Uint8Array
 type LastLedgerSequenceJSON = number
 type XRPDropsAmountJSON = string
 type CurrencyAmountJSON = IssuedCurrencyAmountJSON | XRPDropsAmountJSON
@@ -403,15 +405,39 @@ const serializer = {
    * @returns The Memo as JSON.
    */
   memoToJSON(memo: Memo): MemoJSON {
-    const jsonMemo: MemoDetailsJSON = {
-      MemoData: memo.getMemoData()?.getValue_asU8(),
-      MemoFormat: memo.getMemoFormat()?.getValue_asU8(),
-      MemoType: memo.getMemoType()?.getValue_asU8(),
+    const memoData = memo.getMemoData()
+    const memoFormat = memo.getMemoFormat()
+    const memoType = memo.getMemoType()
+
+    const jsonMemo: MemoDetailsJSON = {}
+
+    if (memoData !== undefined) {
+      jsonMemo.MemoData = this.memoDataToJSON(memoData)
+    }
+
+    if (memoFormat !== undefined) {
+      jsonMemo.MemoFormat = this.memoDataToJSON(memoFormat)
+    }
+
+    if (memoType !== undefined) {
+      jsonMemo.MemoType = this.memoDataToJSON(memoType)
     }
 
     return {
       Memo: jsonMemo,
     }
+  },
+
+  /**
+   * Convert a MemoData to a JSON representation.
+   *
+   * @param memoData - The MemoData to convert.
+   * @returns The MemoData as JSON.
+   */
+  memoDataToJSON(memoData: MemoData): MemoDataJSON | undefined {
+    return memoData.getValue_asU8().length > 0
+      ? memoData.getValue_asU8()
+      : undefined
   },
 
   /**
@@ -475,7 +501,7 @@ const serializer = {
   ): LastLedgerSequenceJSON {
     return lastLedgerSequence.getValue()
   },
-  
+
   /**
    * Convert a ClearFlag to a JSON representation.
    *
@@ -485,7 +511,7 @@ const serializer = {
   clearFlagToJSON(clearFlag: ClearFlag): ClearFlagJSON {
     return clearFlag.getValue()
   },
-    
+
   /**
    * Convert an EmailHash to a JSON representation.
    *

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -44,7 +44,11 @@ import {
   DepositPreauth,
   AccountSet,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
-import Serializer from '../../src/XRP/serializer'
+import Serializer, {
+  AccountSetJSON,
+  DepositPreauthJSON,
+  TransactionJSON,
+} from '../../src/XRP/serializer'
 import XrpUtils from '../../src/XRP/xrp-utils'
 
 /** Constants for transactions. */
@@ -441,7 +445,7 @@ describe('serializer', function (): void {
     const serialized = Serializer.transactionToJSON(transaction)
 
     // THEN the result is as expected.
-    const expectedJSON = {
+    const expectedJSON: TransactionJSON = {
       Account: accountClassicAddress,
       Amount: value.toString(),
       Destination: destinationClassicAddress,
@@ -470,7 +474,7 @@ describe('serializer', function (): void {
     const serialized = Serializer.transactionToJSON(transaction)
 
     // THEN the result is as expected.
-    const expectedJSON = {
+    const expectedJSON: TransactionJSON = {
       Account: XrpUtils.decodeXAddress(accountXAddress)!.address,
       Amount: value.toString(),
       Destination: destinationClassicAddress,
@@ -538,7 +542,7 @@ describe('serializer', function (): void {
     const serialized = Serializer.transactionToJSON(transaction)
 
     // THEN the result is as expected.
-    const expectedJSON = {
+    const expectedJSON: TransactionJSON = {
       Account: accountClassicAddress,
       Amount: value.toString(),
       Destination: destinationClassicAddress,
@@ -568,7 +572,7 @@ describe('serializer', function (): void {
     const serialized = Serializer.transactionToJSON(transaction)
 
     // THEN the result is as expected.
-    const expectedJSON = {
+    const expectedJSON: TransactionJSON = {
       Account: accountClassicAddress,
       Amount: value.toString(),
       Destination: destinationClassicAddress,
@@ -611,7 +615,7 @@ describe('serializer', function (): void {
     const serialized = Serializer.transactionToJSON(transaction)
 
     // THEN the result still has the meme as expected.
-    const expectedJSON = {
+    const expectedJSON: TransactionJSON = {
       Account: accountClassicAddress,
       Amount: value.toString(),
       Destination: destinationClassicAddress,
@@ -685,7 +689,7 @@ describe('serializer', function (): void {
     const depositPreauth = new DepositPreauth()
     depositPreauth.setAuthorize(authorize)
 
-    const expectedJSON = {
+    const expectedJSON: DepositPreauthJSON = {
       Authorize: address,
       TransactionType: 'DepositPreauth',
     }
@@ -710,7 +714,7 @@ describe('serializer', function (): void {
     const depositPreauth = new DepositPreauth()
     depositPreauth.setUnauthorize(unauthorize)
 
-    const expectedJSON = {
+    const expectedJSON: DepositPreauthJSON = {
       TransactionType: 'DepositPreauth',
       Unauthorize: address,
     }
@@ -778,7 +782,7 @@ describe('serializer', function (): void {
       undefined,
       undefined,
     )
-    const expectedJSON = {
+    const expectedJSON: AccountSetJSON = {
       TransactionType: 'AccountSet',
     }
 
@@ -811,7 +815,7 @@ describe('serializer', function (): void {
       tickSizeValue,
     )
 
-    const expectedJSON = {
+    const expectedJSON: AccountSetJSON = {
       ClearFlag: clearFlagValue,
       Domain: domainValue,
       EmailHash: Utils.toHex(emailHashValue),

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1054,7 +1054,7 @@ describe('serializer', function (): void {
     // THEN the result is the input.
     assert.equal(serialized, flagValues)
   })
-    
+
   it('Serializes an EmailHash', function (): void {
     // GIVEN an EmailHash.
     const emailHashBytes = new Uint8Array([1, 2, 3, 4])

--- a/test/XRP/signer.test.ts
+++ b/test/XRP/signer.test.ts
@@ -19,7 +19,7 @@ import {
   Payment,
   Transaction,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
-import Serializer from '../../src/XRP/serializer'
+import Serializer, { TransactionJSON } from '../../src/XRP/serializer'
 import Signer from '../../src/XRP/signer'
 import XrpUtils from '../../src/XRP/xrp-utils'
 
@@ -106,7 +106,7 @@ describe('signer', function (): void {
       'X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4',
     )
 
-    const transactionJSON = {
+    const transactionJSON: TransactionJSON = {
       Account: sourceAddress!.address,
       Fee: '10',
       Sequence: 1,


### PR DESCRIPTION
## High Level Overview of Change

Refactor some types in Serializer to make things more clear. 

### Context of Change

After this change:
- Each protobuf maps 1:1 with a JSON type. Ex. `Foo` maps to `FooJSON`. 
- `BaseTransactionJSON` contains the [Common Transaction Fields](https://xrpl.org/transaction-common-fields.html).
- Each transaction type has a type with the specific fields (ex. `AccountSetJSON`, `PaymentJSON`)
- `TransactionDataJSON` represents an OR of all transaction specific fields
- Each transaction specific field gets ANDed with the base fields as a type, ex. `AccountSetJSON` AND `BaseTransactionJSON` becomes `AccountSetTransactionJSON`. 
- `Transaction` is an OR of all possible combinations of transaction specific fields and common fields. 

A few types are exported so the test can compile. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI

<!--
## Future Tasks
For future tasks related to PR.
-->
