### PR TITLE
Revert #442

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -341,11 +341,6 @@
           }
         }
       }
-    },
-    "@payid-org/utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@payid-org/utils/-/utils-1.0.0.tgz",
-      "integrity": "sha512-ioBevMe3ROgZBRM+3I28lCy2+5+BJpEEOxzbGd6SXtvNhwIjQPqpKWH7xwV5zh/1JOURFtCPUri07BOZ0MCHaA=="
     },
     "@types/chai": {
       "version": "4.2.12",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "webpack": "npm run clean && ./scripts/regenerate_protos.sh && npm run lint && tsc --noEmit && webpack && copyfiles -u 3 './src/XRP/generated/**/*' ./dist/XRP/generated"
   },
   "dependencies": {
-    "@payid-org/utils": "^1.0.0",
     "bip32": "2.0.5",
     "bip39": "^3.0.2",
     "google-protobuf": "3.12.4",

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -1,5 +1,3 @@
-import * as utils from '@payid-org/utils'
-
 import PayIdComponents from './pay-id-components'
 
 /**
@@ -13,13 +11,38 @@ const payIdUtils = {
    * @returns A PayIdComponents object if the input was valid, otherwise undefined.
    */
   parsePayId(payId: string): PayIdComponents | undefined {
-    try {
-      utils.parsePayId(payId)
-      const [path, host] = utils.splitPayIdString(payId)
-      return new PayIdComponents(host, `/${path}`)
-    } catch {
+    if (!this.isASCII(payId)) {
       return undefined
     }
+
+    // Split on the last occurrence of '$'
+    const lastDollarIndex = payId.lastIndexOf('$')
+    if (lastDollarIndex === -1) {
+      return undefined
+    }
+    const path = payId.slice(0, lastDollarIndex)
+    const host = payId.slice(lastDollarIndex + 1)
+
+    // Validate the host and path have values.
+    if (host.length === 0 || path.length === 0) {
+      return undefined
+    }
+
+    return new PayIdComponents(host, `/${path}`)
+  },
+
+  /**
+   * Validate if the input is ASCII based text.
+   *
+   * Shamelessly taken from:
+   * https://stackoverflow.com/questions/14313183/javascript-regex-how-do-i-check-if-the-string-is-ascii-only.
+   *
+   * @param input - The input to check.
+   * @returns A boolean indicating the result.
+   */
+  isASCII(input: string): boolean {
+    // eslint-disable-next-line no-control-regex -- The ASCII regex uses control characters
+    return /^[\x00-\x7F]*$/u.test(input)
   },
 }
 export default payIdUtils


### PR DESCRIPTION
## High Level Overview of Change

Revert #442 which introduced an unpackable payid parser

### Context of Change

After merging #442, we cannot execute this code in Swift / Java VMs.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

Builds should work

## Test Plan

CI