### PR TITLE
Serialization for DeliverMin Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -766,8 +766,12 @@ const serializer = {
    */
   deliverMinToJSON(deliverMin: DeliverMin): DeliverMinJSON | undefined {
     const currencyAmount = deliverMin.getValue()
+    if (currencyAmount === undefined) {
+      return undefined
+    }
+    return this.currencyAmountToJSON(currencyAmount)
   },
-    
+
   /**
    * Convert a CheckID to a JSON representation.
    *

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -29,6 +29,7 @@ import {
   MemoType,
   Unauthorize,
   Destination,
+  DeliverMin,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -122,6 +123,7 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type DeliverMinJSON = CurrencyAmountJSON
 type DestinationJSON = AccountAddressJSON
 type AccountAddressJSON = string
 type AmountJSON = CurrencyAmountJSON
@@ -742,6 +744,20 @@ const serializer = {
       return undefined
     }
     return this.accountAddressToJSON(accountAddress)
+  },
+
+  /**
+   * Convert a DeliverMin to a JSON respresentation.
+   *
+   * @param deliverMin - The DeliverMin to convert.
+   * @returns The DeliverMin as JSON.
+   */
+  deliverMinToJSON(deliverMin: DeliverMin): DeliverMinJSON | undefined {
+    const currencyAmount = deliverMin.getValue()
+    if (currencyAmount === undefined) {
+      return undefined
+    }
+    return this.currencyAmountToJSON(currencyAmount)
   },
 }
 

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -3,6 +3,7 @@
  */
 import Utils from '../Common/utils'
 
+import { AccountAddress } from './generated/org/xrpl/rpc/v1/account_pb'
 import {
   XRPDropsAmount,
   Currency,
@@ -27,6 +28,7 @@ import {
   MemoFormat,
   MemoType,
   Unauthorize,
+  Destination,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -120,6 +122,8 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type DestinationJSON = AccountAddressJSON
+type AccountAddressJSON = string
 type AmountJSON = CurrencyAmountJSON
 type MemoDataJSON = string
 type MemoTypeJSON = string
@@ -528,6 +532,16 @@ const serializer = {
   },
 
   /**
+   * Convert an Account Address to a JSON representation.
+   *
+   * @param accountAddress - The AccountAddress to convert.
+   * @returns The AccountAddress as JSON.
+   */
+  accountAddressToJSON(accountAddress: AccountAddress): AccountAddressJSON {
+    return accountAddress.getAddress()
+  },
+
+  /**
    * Convert an Unauthorize to a JSON representation.
    *
    * @param unauthorize - The Unauthorize to convert.
@@ -714,6 +728,20 @@ const serializer = {
       default:
         return undefined
     }
+  },
+
+  /**
+   * Convert a Destination to a JSON representation.
+   *
+   * @param destination - The Destination to convert.
+   * @returns The Destination as JSON.
+   */
+  destinationToJSON(destination: Destination): DestinationJSON | undefined {
+    const accountAddress = destination.getValue()
+    if (accountAddress === undefined) {
+      return undefined
+    }
+    return this.accountAddressToJSON(accountAddress)
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1292,4 +1292,30 @@ describe('serializer', function (): void {
     // THEN the result is the hex representation of the bytes.
     assert.equal(serialized, Utils.toHex(memoFormatBytes))
   })
+
+  it('Serializes a Destination', function (): void {
+    // GIVEN a Destination
+    const destination = new Destination()
+    destination.setValue(testAccountAddress)
+
+    // WHEN it is serialized
+    const serialized = Serializer.destinationToJSON(destination)
+
+    // THEN the result is the serialized representation of the input.
+    assert.equal(
+      serialized,
+      Serializer.accountAddressToJSON(testAccountAddress),
+    )
+  })
+
+  it('Fails to serialize a malformed destination', function (): void {
+    // GIVEN a Destination with no address
+    const destination = new Destination()
+
+    // WHEN it is serialized
+    const serialized = Serializer.destinationToJSON(destination)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1385,7 +1385,7 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized
     const serialized = Serializer.destinationToJSON(destination)
-    
+
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
@@ -1396,13 +1396,28 @@ describe('serializer', function (): void {
 
     const currencyAmount = new CurrencyAmount()
     currencyAmount.setXrpAmount(xrpDropsAmount)
-    
+
     const deliverMin = new DeliverMin()
     deliverMin.setValue(currencyAmount)
 
     // WHEN it is serialized
-    const serialized = Serializer.deliverMinToJSON(deliverMin)    
-    
+    const serialized = Serializer.deliverMinToJSON(deliverMin)
+
+    // THEN the result is the serialized representation of the input.
+    assert.equal(serialized, Serializer.currencyAmountToJSON(currencyAmount))
+  })
+
+  it('Fails to serialize a malformed DeliverMin', function (): void {
+    // GIVEN a DeliverMin with no value
+    const destination = new DeliverMin()
+
+    // WHEN it is serialized
+    const serialized = Serializer.deliverMinToJSON(destination)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
   it('Serializes a CheckID', function (): void {
     // GIVEN a CheckID.
     const checkIdValue = new Uint8Array([1, 2, 3, 4])
@@ -1433,13 +1448,6 @@ describe('serializer', function (): void {
     // THEN the result is the serialized representation of the input.
     assert.equal(serialized, Serializer.currencyAmountToJSON(currencyAmount))
   })
-
-  it('Fails to serialize a malformed DeliverMin', function (): void {
-    // GIVEN a DeliverMin with no value
-    const destination = new DeliverMin()
-
-    // WHEN it is serialized
-    const serialized = Serializer.deliverMinToJSON(destination)
 
   it('Fails to serialize a malformed SendMax', function (): void {
     // GIVEN a DeliverMin with no value.

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -36,6 +36,7 @@ import {
   LastLedgerSequence,
   DestinationTag,
   InvoiceID,
+  DeliverMin,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1308,12 +1309,40 @@ describe('serializer', function (): void {
     )
   })
 
-  it('Fails to serialize a malformed destination', function (): void {
+  it('Fails to serialize a malformed Destination', function (): void {
     // GIVEN a Destination with no address
     const destination = new Destination()
 
     // WHEN it is serialized
     const serialized = Serializer.destinationToJSON(destination)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Serializes a DeliverMin', function (): void {
+    // GIVEN a DeliverMin.
+    const xrpDropsAmount = makeXrpDropsAmount('10')
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(xrpDropsAmount)
+
+    const deliverMin = new DeliverMin()
+    deliverMin.setValue(currencyAmount)
+
+    // WHEN it is serialized
+    const serialized = Serializer.deliverMinToJSON(deliverMin)
+
+    // THEN the result is the serialized representation of the input.
+    assert.equal(serialized, Serializer.currencyAmountToJSON(currencyAmount))
+  })
+
+  it('Fails to serialize a malformed DeliverMin', function (): void {
+    // GIVEN a DeliverMin with no value
+    const destination = new DeliverMin()
+
+    // WHEN it is serialized
+    const serialized = Serializer.deliverMinToJSON(destination)
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for DeliverMin protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `DeliverMin` and adds associated unit tests. 

Docs for `DeliverMin`: https://xrpl.org/payment.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 