### PR TITLE
Add Serialization for SendMax

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -27,6 +27,7 @@ import {
   MemoFormat,
   MemoType,
   Unauthorize,
+  SendMax,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -120,6 +121,7 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type SendMaxJSON = CurrencyAmountJSON
 type AmountJSON = CurrencyAmountJSON
 type MemoDataJSON = string
 type MemoTypeJSON = string
@@ -714,6 +716,20 @@ const serializer = {
       default:
         return undefined
     }
+  },
+
+  /**
+   * Convert a SendMax to a JSON respresentation.
+   *
+   * @param sendMax - The SendMax to convert.
+   * @returns The SendMax as JSON.
+   */
+  sendMaxToJSON(sendMax: SendMax): SendMaxJSON | undefined {
+    const currencyAmount = sendMax.getValue()
+    if (currencyAmount === undefined) {
+      return undefined
+    }
+    return this.currencyAmountToJSON(currencyAmount)
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -36,6 +36,7 @@ import {
   LastLedgerSequence,
   DestinationTag,
   InvoiceID,
+  SendMax,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1291,5 +1292,33 @@ describe('serializer', function (): void {
 
     // THEN the result is the hex representation of the bytes.
     assert.equal(serialized, Utils.toHex(memoFormatBytes))
+  })
+
+  it('Serializes a SendMax', function (): void {
+    // GIVEN a SendMax.
+    const xrpDropsAmount = makeXrpDropsAmount('10')
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(xrpDropsAmount)
+
+    const sendMax = new SendMax()
+    sendMax.setValue(currencyAmount)
+
+    // WHEN it is serialized
+    const serialized = Serializer.sendMaxToJSON(sendMax)
+
+    // THEN the result is the serialized representation of the input.
+    assert.equal(serialized, Serializer.currencyAmountToJSON(currencyAmount))
+  })
+
+  it('Fails to serialize a malformed SendMax', function (): void {
+    // GIVEN a DeliverMin with no value
+    const destination = new SendMax()
+
+    // WHEN it is serialized
+    const serialized = Serializer.sendMaxToJSON(destination)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1304,7 +1304,7 @@ describe('serializer', function (): void {
     const sendMax = new SendMax()
     sendMax.setValue(currencyAmount)
 
-    // WHEN it is serialized
+    // WHEN it is serialized.
     const serialized = Serializer.sendMaxToJSON(sendMax)
 
     // THEN the result is the serialized representation of the input.

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1312,7 +1312,7 @@ describe('serializer', function (): void {
   })
 
   it('Fails to serialize a malformed SendMax', function (): void {
-    // GIVEN a DeliverMin with no value
+    // GIVEN a DeliverMin with no value.
     const destination = new SendMax()
 
     // WHEN it is serialized


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for SendMax protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `SendMax` and adds associated unit tests. 

Docs for `SendMax`: https://xrpl.org/payment.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 