### PR TITLE
Serialization for Expiration

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -27,6 +27,7 @@ import {
   MemoFormat,
   MemoType,
   Unauthorize,
+  Expiration,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -120,6 +121,7 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type ExpirationJSON = number
 type AmountJSON = CurrencyAmountJSON
 type MemoDataJSON = string
 type MemoTypeJSON = string
@@ -714,6 +716,16 @@ const serializer = {
       default:
         return undefined
     }
+  },
+
+  /**
+   * Convert an Expiration to a JSON representation.
+   *
+   * @param expiration - The Expiration to convert.
+   * @returns The Expiration as JSON.
+   */
+  expirationToJSON(expiration: Expiration): ExpirationJSON {
+    return expiration.getValue()
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -36,6 +36,7 @@ import {
   LastLedgerSequence,
   DestinationTag,
   InvoiceID,
+  Expiration,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1291,5 +1292,19 @@ describe('serializer', function (): void {
 
     // THEN the result is the hex representation of the bytes.
     assert.equal(serialized, Utils.toHex(memoFormatBytes))
+  })
+
+  it('Serializes an Expiration', function (): void {
+    // GIVEN an Expiration with an expiration time
+    const expirationTime = 12
+
+    const expiration = new Expiration()
+    expiration.setValue(expirationTime)
+
+    // WHEN it is serialized
+    const serialized = Serializer.expirationToJSON(expiration)
+
+    // THEN the result is the expiration time.
+    assert.equal(serialized, expirationTime)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1324,7 +1324,7 @@ describe('serializer', function (): void {
     const expiration = new Expiration()
     expiration.setValue(expirationTime)
 
-    // WHEN it is serialized
+    // WHEN it is serialized.
     const serialized = Serializer.expirationToJSON(expiration)
 
     // THEN the result is the expiration time.

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1318,7 +1318,7 @@ describe('serializer', function (): void {
   })
 
   it('Serializes an Expiration', function (): void {
-    // GIVEN an Expiration with an expiration time
+    // GIVEN an Expiration with an expiration time.
     const expirationTime = 12
 
     const expiration = new Expiration()


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for `Expiration` protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `Expiration` and adds associated unit tests. 

Docs for `Expiration`: https://xrpl.org/checkcreate.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 