### PR TITLE
Serialization for CheckCancel

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -11,6 +11,7 @@ import {
 } from './generated/org/xrpl/rpc/v1/amount_pb'
 import {
   Authorize,
+  CheckID,
   ClearFlag,
   DestinationTag,
   Domain,
@@ -120,6 +121,7 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type CheckIDJSON = string
 type AmountJSON = CurrencyAmountJSON
 type MemoDataJSON = string
 type MemoTypeJSON = string
@@ -714,6 +716,16 @@ const serializer = {
       default:
         return undefined
     }
+  },
+
+  /**
+   * Convert a CheckID to a JSON representation.
+   *
+   * @param checkId - The CheckID to convert.
+   * @returns The CheckID as JSON.
+   */
+  checkIDToJSON(checkId: CheckID): CheckIDJSON {
+    return Utils.toHex(checkId.getValue_asU8())
   },
 }
 

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -35,6 +35,7 @@ import {
   Payment,
   Transaction,
   DepositPreauth,
+  CheckCancel,
 } from './generated/org/xrpl/rpc/v1/transaction_pb'
 import XrpUtils from './xrp-utils'
 
@@ -78,13 +79,22 @@ interface PaymentJSON {
   TransactionType: 'Payment'
 }
 
+interface CheckCancelJSON {
+  CheckID: CheckIDJSON
+}
+
 // Generic field representing an OR of all above fields.
-type TransactionDataJSON = AccountSetJSON | DepositPreauthJSON | PaymentJSON
+type TransactionDataJSON =
+  | AccountSetJSON
+  | CheckCancelJSON
+  | DepositPreauthJSON
+  | PaymentJSON
 
 /**
  * Individual Transaction Types.
  */
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSON
+type CheckCancelTransactionJSON = BaseTransactionJSON & CheckCancelJSON
 type DepositPreauthTransactionJSON = BaseTransactionJSON & DepositPreauthJSON
 type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
 
@@ -93,6 +103,7 @@ type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
  */
 export type TransactionJSON =
   | AccountSetTransactionJSON
+  | CheckCancelTransactionJSON
   | DepositPreauthTransactionJSON
   | PaymentTransactionJSON
 
@@ -726,6 +737,23 @@ const serializer = {
    */
   checkIDToJSON(checkId: CheckID): CheckIDJSON {
     return Utils.toHex(checkId.getValue_asU8())
+  },
+
+  /**
+   * Convert a CheckCancel to a JSON representation.
+   *
+   * @param checkCancel - The CheckCancel to convert.
+   * @returns The CheckCancel as JSON.
+   */
+  checkCancelToJSON(checkCancel: CheckCancel): CheckCancelJSON | undefined {
+    const checkId = checkCancel.getCheckId()
+    if (checkId === undefined) {
+      return undefined
+    }
+
+    return {
+      CheckID: this.checkIDToJSON(checkId),
+    }
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -44,6 +44,7 @@ import {
   Transaction,
   DepositPreauth,
   AccountSet,
+  CheckCancel,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer, {
   AccountSetJSON,
@@ -1306,5 +1307,36 @@ describe('serializer', function (): void {
 
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(checkIdValue))
+  })
+
+  it('Serializes a CheckCancel', function (): void {
+    // GIVEN a CheckCancel.
+    const checkIdValue = new Uint8Array([1, 2, 3, 4])
+
+    const checkId = new CheckID()
+    checkId.setValue(checkIdValue)
+
+    const checkCancel = new CheckCancel()
+    checkCancel.setCheckId(checkId)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.checkCancelToJSON(checkCancel)
+
+    // THEN the output is in the expected form.
+    const expected = {
+      CheckID: Serializer.checkIDToJSON(checkId),
+    }
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Fails to serialize a malformed CheckCancel', function (): void {
+    // GIVEN a CheckCancel with no data..
+    const checkCancel = new CheckCancel()
+
+    // WHEN it is serialized.
+    const serialized = Serializer.checkCancelToJSON(checkCancel)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -36,6 +36,7 @@ import {
   LastLedgerSequence,
   DestinationTag,
   InvoiceID,
+  CheckID,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1291,5 +1292,19 @@ describe('serializer', function (): void {
 
     // THEN the result is the hex representation of the bytes.
     assert.equal(serialized, Utils.toHex(memoFormatBytes))
+  })
+
+  it('Serializes a CheckID', function (): void {
+    // GIVEN a CheckID.
+    const checkIdValue = new Uint8Array([1, 2, 3, 4])
+
+    const checkId = new CheckID()
+    checkId.setValue(checkIdValue)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.checkIDToJSON(checkId)
+
+    // THEN the output is the input encoded as hex.
+    assert.equal(serialized, Utils.toHex(checkIdValue))
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for CheckCancel protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `CheckCancel` and adds associated unit tests. 

Docs for `CheckCancel`: https://xrpl.org/checkcancel.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 