### PR TITLE
OfferCancel Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -46,13 +46,11 @@ import {
   Payment,
   Transaction,
   DepositPreauth,
-  OfferCreate,
   OfferCancel,
   CheckCancel,
   EscrowCancel,
 } from './generated/org/xrpl/rpc/v1/transaction_pb'
 import XrpUtils from './xrp-utils'
-import { Offer } from './generated/org/xrpl/rpc/v1/ledger_objects_pb'
 
 /**
  * Common fields on a transaction.
@@ -93,15 +91,15 @@ export interface EscrowCancelJSON {
   TransactionType: 'EscrowCancel'
 }
 
+interface OfferCancelJSON {
+  OfferSequence: OfferSequenceJSON
+}
+
 interface PaymentJSON {
   Amount: AmountJSON
   Destination: string
   DestinationTag?: DestinationTagJSON
   TransactionType: 'Payment'
-}
-
-interface OfferCreateJSON {
-  OfferSequence: OfferSequenceJSON
 }
 
 interface CheckCancelJSON {
@@ -114,7 +112,7 @@ type TransactionDataJSON =
   | CheckCancelJSON
   | DepositPreauthJSON
   | EscrowCancelJSON
-  | OfferCreateJSON
+  | OfferCancelJSON
   | PaymentJSON
 
 /**
@@ -123,7 +121,7 @@ type TransactionDataJSON =
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSON
 type CheckCancelTransactionJSON = BaseTransactionJSON & CheckCancelJSON
 type DepositPreauthTransactionJSON = BaseTransactionJSON & DepositPreauthJSON
-type OfferCreateTransactionJSON = BaseTransactionJSON & OfferCreateJSON
+type OfferCancelTransactionJSON = BaseTransactionJSON & OfferCancelJSON
 type EscrowCancelTransactionJSON = BaseTransactionJSON & EscrowCancelJSON
 type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
 
@@ -135,7 +133,7 @@ export type TransactionJSON =
   | CheckCancelTransactionJSON
   | DepositPreauthTransactionJSON
   | EscrowCancelTransactionJSON
-  | OfferCreateTransactionJSON
+  | OfferCancelTransactionJSON
   | PaymentTransactionJSON
 
 /**
@@ -369,9 +367,9 @@ const serializer = {
    * @returns The Owner as JSON.
    */
   ownerToJSON(owner: Owner): OwnerJSON | undefined {
-    const accountAddress = owner.getValue();
+    const accountAddress = owner.getValue()
     if (accountAddress === undefined) {
-      return undefined;
+      return undefined
     }
 
     return this.accountAddressToJSON(accountAddress)
@@ -885,8 +883,8 @@ const serializer = {
       CheckID: this.checkIDToJSON(checkId),
     }
   },
-    
-  /**    
+
+  /**
    * Convert a SendMax to a JSON respresentation.
    *
    * @param sendMax - The SendMax to convert.
@@ -971,10 +969,14 @@ const serializer = {
    * @returns The OfferCancel as JSON.
    */
   offerCancelToJSON(offerCancel: OfferCancel): OfferCancelJSON | undefined {
-    const x = offerCancel.getOfferSequence()
+    const offerSequence = offerCancel.getOfferSequence()
+    if (offerSequence === undefined) {
+      return undefined
+    }
 
-    // TODO(keefertaylor): Use accountAddressToJSON() here when supported.
-    return account.getValue()?.getAddress()
+    return {
+      OfferSequence: this.offerSequenceToJSON(offerSequence),
+    }
   },
 }
 

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -41,8 +41,11 @@ import {
   Payment,
   Transaction,
   DepositPreauth,
+  OfferCreate,
+  OfferCancel,
 } from './generated/org/xrpl/rpc/v1/transaction_pb'
 import XrpUtils from './xrp-utils'
+import { Offer } from './generated/org/xrpl/rpc/v1/ledger_objects_pb'
 
 /**
  * Common fields on a transaction.
@@ -84,14 +87,19 @@ interface PaymentJSON {
   TransactionType: 'Payment'
 }
 
+interface OfferCreateJSON {
+  OfferSequence: OfferSequenceJSON
+}
+
 // Generic field representing an OR of all above fields.
-type TransactionDataJSON = AccountSetJSON | DepositPreauthJSON | PaymentJSON
+type TransactionDataJSON = AccountSetJSON | DepositPreauthJSON | OfferCreateJSON | PaymentJSON
 
 /**
  * Individual Transaction Types.
  */
 type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSON
 type DepositPreauthTransactionJSON = BaseTransactionJSON & DepositPreauthJSON
+type OfferCreateTransactionJSON = BaseTransactionJSON & OfferCreateJSON
 type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
 
 /**
@@ -100,6 +108,7 @@ type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
 export type TransactionJSON =
   | AccountSetTransactionJSON
   | DepositPreauthTransactionJSON
+  | OfferCreateTransactionJSON
   | PaymentTransactionJSON
 
 /**
@@ -805,6 +814,19 @@ const serializer = {
    * @returns The Account as JSON.
    */
   accountToJSON(account: Account): AccountJSON | undefined {
+    // TODO(keefertaylor): Use accountAddressToJSON() here when supported.
+    return account.getValue()?.getAddress()
+  },
+
+  /**
+   * Convert an OfferCancel to a JSON representation.
+   *
+   * @param offerCancel - The OfferCancel to convert.
+   * @returns The OfferCancel as JSON.
+   */
+  offerCancelToJSON(offerCancel: OfferCancel): OfferCancelJSON | undefined {
+    const x = offerCancel.getOfferSequence()
+
     // TODO(keefertaylor): Use accountAddressToJSON() here when supported.
     return account.getValue()?.getAddress()
   },

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -53,6 +53,7 @@ import {
   AccountSet,
   CheckCancel,
   EscrowCancel,
+  OfferCancel,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer, {
   EscrowCancelJSON,
@@ -1465,11 +1466,11 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized.
     const serialized = Serializer.checkCancelToJSON(checkCancel)
-    
+
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Serializes a SendMax', function (): void {
     // GIVEN a SendMax.
     const xrpDropsAmount = makeXrpDropsAmount('10')
@@ -1650,6 +1651,35 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized.
     const serialized = Serializer.escrowCancelToJSON(escrowCancel)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Serializes an OfferCancel', function (): void {
+    // GIVEN a OfferCancel.
+    const offerSequence = new OfferSequence()
+    offerSequence.setValue(offerSequenceNumber)
+
+    const offerCancel = new OfferCancel()
+    offerCancel.setOfferSequence(offerSequence)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.offerCancelToJSON(offerCancel)
+
+    // THEN the output is in the expected form.
+    const expected = {
+      OfferSequence: Serializer.offerSequenceToJSON(offerSequence),
+    }
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Fails to serialize a malformed OfferCancel', function (): void {
+    // GIVEN a OfferCancel with no data.
+    const offerCancel = new OfferCancel()
+
+    // WHEN it is serialized.
+    const serialized = Serializer.offerCancelToJSON(offerCancel)
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for OfferCancel protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `OfferCancel` and adds associated unit tests. 

Docs: https://xrpl.org/offercancel.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 