### PR TITLE
Serialization for OfferSeqence

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -34,6 +34,7 @@ import {
   SigningPublicKey,
   Expiration,
   Account,
+  OfferSequence,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -127,6 +128,7 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type OfferSequenceJSON = number
 type AccountAddressJSON = string
 type CheckIDJSON = string
 type SendMaxJSON = CurrencyAmountJSON
@@ -807,6 +809,16 @@ const serializer = {
   accountToJSON(account: Account): AccountJSON | undefined {
     // TODO(keefertaylor): Use accountAddressToJSON() here when supported.
     return account.getValue()?.getAddress()
+  },
+
+  /**
+   * Convert an OfferSequence to a JSON representation.
+   *
+   * @param offerSequence - The OfferSequence to convert.
+   * @returns The OfferSequence as JSON.
+   */
+  offerSequenceToJSON(offerSequence: OfferSequence): OfferSequenceJSON {
+    return offerSequence.getValue()
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -40,6 +40,7 @@ import {
   SendMax,
   TransactionSignature,
   Expiration,
+  OfferSequence,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1417,5 +1418,19 @@ describe('serializer', function (): void {
 
     // THEN the result is the expiration time.
     assert.equal(serialized, expirationTime)
+  })
+
+  it('Serializes an OfferSequence', function (): void {
+    // GIVEN an OfferSequence with an expiration time.
+    const offerSequencValue = 12
+
+    const offerSequence = new OfferSequence()
+    offerSequence.setValue(offerSequencValue)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.offerSequenceToJSON(offerSequence)
+
+    // THEN the result is the expiration time.
+    assert.equal(serialized, offerSequencValue)
   })
 })


### PR DESCRIPTION

## High Level Overview of Change

Provides serialization for OfferSeqence protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `OfferSeqence` and adds associated unit tests. 

Docs: https://xrpl.org/offercancel.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 