### PR TITLE
Serialize TakerGets Protocol Buffer

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -34,6 +34,7 @@ import {
   SigningPublicKey,
   Expiration,
   Account,
+  TakerGets,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -155,6 +156,7 @@ type AuthorizeJSON = string
 type InvoiceIdJSON = string
 type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
+type TakerGetsJSON = CurrencyAmountJSON
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -796,6 +798,21 @@ const serializer = {
    */
   expirationToJSON(expiration: Expiration): ExpirationJSON {
     return expiration.getValue()
+  },
+
+  /**
+   * Convert a TakerGets to a JSON representation.
+   *
+   * @param takerGets - The TakerGets to convert.
+   * @returns The TakerGets as JSON.
+   */
+  takerGetsToJSON(takerGets: TakerGets): TakerGetsJSON | undefined {
+    const currencyAmount = takerGets.getValue()
+    if (currencyAmount === undefined) {
+      return undefined
+    }
+
+    return this.currencyAmountToJSON(currencyAmount)
   },
 
   /**

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -40,6 +40,7 @@ import {
   SendMax,
   TransactionSignature,
   Expiration,
+  TakerGets,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1417,5 +1418,43 @@ describe('serializer', function (): void {
 
     // THEN the result is the expiration time.
     assert.equal(serialized, expirationTime)
+  })
+
+  it('Serializes a TakerGets', function (): void {
+    // GIVEN an TakerGets with a CurrencyAmount.
+    const currency = new Currency()
+    currency.setCode('USD')
+
+    const issuedCurrencyAmount = makeIssuedCurrencyAmount(
+      testAccountAddress,
+      '123',
+      currency,
+    )
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setIssuedCurrencyAmount(issuedCurrencyAmount)
+
+    const takerGets = new TakerGets()
+    takerGets.setValue(currencyAmount)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.takerGetsToJSON(takerGets)
+
+    // THEN the result is the serialized CurrencyAmount.
+    assert.deepEqual(
+      serialized,
+      Serializer.currencyAmountToJSON(currencyAmount),
+    )
+  })
+
+  it('Fails to serialze a malformed TakerGets', function (): void {
+    // GIVEN an TakerGets without a CurrencyAmount.
+    const takerGets = new TakerGets()
+
+    // WHEN it is serialized.
+    const serialized = Serializer.takerGetsToJSON(takerGets)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for TakerGets protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `TakerGets` and adds associated unit tests. 

Docs: https://xrpl.org/offercreate.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 