### PR TITLE
Serialize Check Cash Protocol Buffers

### DIFF
--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -52,6 +52,7 @@ import {
   AccountSet,
   CheckCancel,
   EscrowCancel,
+  CheckCash,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer, {
   EscrowCancelJSON,
@@ -1464,11 +1465,11 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized.
     const serialized = Serializer.checkCancelToJSON(checkCancel)
-    
+
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Serializes a SendMax', function (): void {
     // GIVEN a SendMax.
     const xrpDropsAmount = makeXrpDropsAmount('10')
@@ -1611,6 +1612,91 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized.
     const serialized = Serializer.escrowCancelToJSON(escrowCancel)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Serializes a CheckCash with an Amount', function (): void {
+    // GIVEN a CheckCash with an AMount
+    const xrpDropsAmount = makeXrpDropsAmount('10')
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(xrpDropsAmount)
+
+    const amount = new Amount()
+    amount.setValue(currencyAmount)
+
+    const checkIdValue = new Uint8Array([1, 2, 3, 4])
+    const checkId = new CheckID()
+    checkId.setValue(checkIdValue)
+
+    const checkCash = new CheckCash()
+    checkCash.setCheckId(checkId)
+    checkCash.setAmount(amount)
+
+    // WHEN it is serialized
+    const serialized = Serializer.checkCashToJSON(checkCash)
+
+    // THEN the result is in the expected form.
+    const expected = {
+      CheckID: Serializer.checkIDToJSON(checkId),
+      Amount: Serializer.amountToJSON(amount),
+    }
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Serializes a CheckCash with a DeliverMin', function (): void {
+    // GIVEN a CheckCash with all fields set.
+    const xrpDropsAmount = makeXrpDropsAmount('10')
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(xrpDropsAmount)
+
+    const deliverMin = new DeliverMin()
+    deliverMin.setValue(currencyAmount)
+
+    const checkIdValue = new Uint8Array([1, 2, 3, 4])
+    const checkId = new CheckID()
+    checkId.setValue(checkIdValue)
+
+    const checkCash = new CheckCash()
+    checkCash.setCheckId(checkId)
+    checkCash.setDeliverMin(deliverMin)
+
+    // WHEN it is serialized
+    const serialized = Serializer.checkCashToJSON(checkCash)
+
+    // THEN the result is in the expected form.
+    const expected = {
+      CheckID: Serializer.checkIDToJSON(checkId),
+      DeliverMin: Serializer.deliverMinToJSON(deliverMin),
+    }
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Fails to serialize a malformed CheckCash with only a CheckId', function (): void {
+    // GIVEN a CheckCash with only a CheckID set.
+    const checkIdValue = new Uint8Array([1, 2, 3, 4])
+    const checkId = new CheckID()
+    checkId.setValue(checkIdValue)
+
+    const checkCash = new CheckCash()
+    checkCash.setCheckId(checkId)
+
+    // WHEN it is serialized
+    const serialized = Serializer.checkCashToJSON(checkCash)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Fails to serialize a malformed CheckCash without a CheckID', function (): void {
+    // GIVEN a CheckCash missing the mandatory CheckID field.
+    const checkCash = new CheckCash()
+
+    // WHEN it is serialized
+    const serialized = Serializer.checkCashToJSON(checkCash)
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1618,7 +1618,7 @@ describe('serializer', function (): void {
   })
 
   it('Serializes a CheckCash with an Amount', function (): void {
-    // GIVEN a CheckCash with an AMount
+    // GIVEN a CheckCash with an Amount
     const xrpDropsAmount = makeXrpDropsAmount('10')
 
     const currencyAmount = new CurrencyAmount()


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for CheckCash protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `CheckCash` and adds associated unit tests. 

Docs: https://xrpl.org/checkcash.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 