### PR TITLE
Add Support For InvoiceId in Payment Protocol Buffer Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -94,6 +94,7 @@ export interface PaymentJSON {
   Amount: AmountJSON
   Destination: string
   DestinationTag?: DestinationTagJSON
+  InvoiceID?: string
   TransactionType: 'Payment'
 }
 
@@ -290,6 +291,11 @@ const serializer = {
     const destinationTag = payment.getDestinationTag()
     if (destinationTag !== undefined) {
       json.DestinationTag = this.destinationTagToJSON(destinationTag)
+    }
+
+    const invoiceId = payment.getInvoiceId()
+    if (invoiceId !== undefined) {
+      json.InvoiceID = this.invoiceIdToJSON(invoiceId)
     }
 
     return json

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1701,10 +1701,14 @@ describe('serializer', function (): void {
     const destinationTag = new DestinationTag()
     destinationTag.setValue(11)
 
+    const invoiceId = new InvoiceID()
+    invoiceId.setValue(new Uint8Array([1, 2, 3, 4]))
+
     const payment = new Payment()
     payment.setAmount(amount)
     payment.setDestination(destination)
     payment.setDestinationTag(destinationTag)
+    payment.setInvoiceId(invoiceId)
 
     // WHEN it is serialized.
     const serialized = Serializer.paymentToJSON(payment)
@@ -1714,6 +1718,7 @@ describe('serializer', function (): void {
       Amount: Serializer.amountToJSON(amount)!,
       Destination: Serializer.destinationToJSON(destination)!,
       DestinationTag: Serializer.destinationTagToJSON(destinationTag),
+      InvoiceID: Serializer.invoiceIdToJSON(invoiceId),
       TransactionType: 'Payment',
     }
     assert.deepEqual(serialized, expected)


### PR DESCRIPTION
## High Level Overview of Change

Serialize `InvoiceID` in `Payment` transactions if it is set. 

### Context of Change

Payment did not serialize all fields previously. This PR wires an additional field. 

Docs: https://xrpl.org/payment.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - Tests updated
