### PR TITLE
Adds serialization for CancelAfter and FinishAfter

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -833,6 +833,7 @@ const serializer = {
     }
     return this.accountAddressToJSON(accountAddress)
   },
+
   /**
    * Convert a CheckID to a JSON representation.
    *

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -37,6 +37,7 @@ import {
   Account,
   OfferSequence,
   Owner,
+  Condition,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -182,6 +183,7 @@ type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type OfferSequenceJSON = number
 type OwnerJSON = string
+type ConditionJSON = string
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -355,9 +357,9 @@ const serializer = {
    * @returns The Owner as JSON.
    */
   ownerToJSON(owner: Owner): OwnerJSON | undefined {
-    const accountAddress = owner.getValue();
+    const accountAddress = owner.getValue()
     if (accountAddress === undefined) {
-      return undefined;
+      return undefined
     }
 
     return this.accountAddressToJSON(accountAddress)
@@ -831,7 +833,7 @@ const serializer = {
     }
     return this.accountAddressToJSON(accountAddress)
   },
-    
+
   /**
    * Convert a CheckID to a JSON representation.
    *
@@ -858,8 +860,8 @@ const serializer = {
       CheckID: this.checkIDToJSON(checkId),
     }
   },
-    
-  /**    
+
+  /**
    * Convert a SendMax to a JSON respresentation.
    *
    * @param sendMax - The SendMax to convert.
@@ -916,6 +918,16 @@ const serializer = {
   accountToJSON(account: Account): AccountJSON | undefined {
     // TODO(keefertaylor): Use accountAddressToJSON() here when supported.
     return account.getValue()?.getAddress()
+  },
+
+  /**
+   * Convert a Condition to a JSON representation.
+   *
+   * @param condition - The Condition to convert.
+   * @returns The Condition as JSON.
+   */
+  conditionToJSON(condition: Condition): ConditionJSON {
+    return condition.getValue_asB64()
   },
 }
 

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -41,7 +41,7 @@ import {
   Owner,
   Condition,
   CancelAfter,
-  FinishAfter
+  FinishAfter,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -969,22 +969,22 @@ const serializer = {
   /**
    * Convert a CancelAfter to a JSON representation.
    *
-   * @param condition - The CancelAfter to convert.
+   * @param cancelAfter - The CancelAfter to convert.
    * @returns The CancelAfter as JSON.
    */
   cancelAfterToJSON(cancelAfter: CancelAfter): CancelAfterJSON {
-    return cancelAfter.getValue();
+    return cancelAfter.getValue()
   },
 
   /**
    * Convert a FinishAfter to a JSON representation.
    *
-   * @param condition - The FinshAfter to convert.
+   * @param finishAfter - The FinshAfter to convert.
    * @returns The FinishAfter as JSON.
    */
   finishAfterToJSON(finishAfter: FinishAfter): FinishAfterJSON {
-    return finishAfter.getValue();
-  }
+    return finishAfter.getValue()
+  },
 }
 
 export default serializer

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -927,7 +927,7 @@ const serializer = {
    * @returns The Condition as JSON.
    */
   conditionToJSON(condition: Condition): ConditionJSON {
-    return condition.getValue_asB64()
+    return Utils.toHex(condition.getValue_asU8())
   },
 }
 

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -833,7 +833,6 @@ const serializer = {
     }
     return this.accountAddressToJSON(accountAddress)
   },
-
   /**
    * Convert a CheckID to a JSON representation.
    *

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -40,6 +40,8 @@ import {
   OfferSequence,
   Owner,
   Condition,
+  CancelAfter,
+  FinishAfter
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -188,6 +190,8 @@ type TakerGetsJSON = CurrencyAmountJSON
 type OfferSequenceJSON = number
 type OwnerJSON = string
 type ConditionJSON = string
+type CancelAfterJSON = number
+type FinishAfterJSON = number
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -961,6 +965,26 @@ const serializer = {
   conditionToJSON(condition: Condition): ConditionJSON {
     return Utils.toHex(condition.getValue_asU8())
   },
+
+  /**
+   * Convert a CancelAfter to a JSON representation.
+   *
+   * @param condition - The CancelAfter to convert.
+   * @returns The CancelAfter as JSON.
+   */
+  cancelAfterToJSON(cancelAfter: CancelAfter): CancelAfterJSON {
+    return cancelAfter.getValue();
+  },
+
+  /**
+   * Convert a FinishAfter to a JSON representation.
+   *
+   * @param condition - The FinshAfter to convert.
+   * @returns The FinishAfter as JSON.
+   */
+  finishAfterToJSON(finishAfter: FinishAfter): FinishAfterJSON {
+    return finishAfter.getValue();
+  }
 }
 
 export default serializer

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -40,11 +40,8 @@ import {
   OfferSequence,
   Owner,
   Condition,
-<<<<<<< HEAD
   CancelAfter,
   FinishAfter,
-=======
->>>>>>> 2dde9bfe8c68d8ae51f9064d69c859947e1c3e1a
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -193,11 +190,8 @@ type TakerGetsJSON = CurrencyAmountJSON
 type OfferSequenceJSON = number
 type OwnerJSON = string
 type ConditionJSON = string
-<<<<<<< HEAD
 type CancelAfterJSON = number
 type FinishAfterJSON = number
-=======
->>>>>>> 2dde9bfe8c68d8ae51f9064d69c859947e1c3e1a
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -16,6 +16,7 @@ import {
   IssuedCurrencyAmount,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/amount_pb'
 import {
+  CancelAfter,
   Account,
   Amount,
   Destination,
@@ -1760,5 +1761,31 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)
+  })
+
+  it('Serializes a CancelAfter', function (): void {
+    // GIVEN a CancelAfter.
+    const cancelAfterTime = 533257958
+    const cancelAfter = new CancelAfter()
+    cancelAfter.setValue(cancelAfterTime)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.cancelAfterToJSON(cancelAfter)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, cancelAfterTime)
+  })
+
+  it('Serializes a FinishAfter', function (): void {
+    // GIVEN a FinishAfter.
+    const finishAfterTime = 5331715585
+    const finishAfter = new CancelAfter()
+    finishAfter.setValue(finishAfterTime)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.cancelAfterToJSON(finishAfter)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, finishAfterTime)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -16,7 +16,6 @@ import {
   IssuedCurrencyAmount,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/amount_pb'
 import {
-  CancelAfter,
   Account,
   Amount,
   Destination,
@@ -46,6 +45,8 @@ import {
   OfferSequence,
   Owner,
   Condition,
+  CancelAfter,
+  FinishAfter,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1779,11 +1780,11 @@ describe('serializer', function (): void {
   it('Serializes a FinishAfter', function (): void {
     // GIVEN a FinishAfter.
     const finishAfterTime = 5331715585
-    const finishAfter = new CancelAfter()
+    const finishAfter = new FinishAfter()
     finishAfter.setValue(finishAfterTime)
 
     // WHEN it is serialized.
-    const serialized = Serializer.cancelAfterToJSON(finishAfter)
+    const serialized = Serializer.finishAfterToJSON(finishAfter)
 
     // THEN the result is as expected.
     assert.equal(serialized, finishAfterTime)

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1589,16 +1589,15 @@ describe('serializer', function (): void {
   })
 
   it('Serializes a Condition', function (): void {
-    // GIVEN a Condition.
-    const conditionByteString =
-      'A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100'
+    // GIVEN a Condition with some bytes.
+    const conditionBytes = new Uint8Array([0, 1, 2, 3])
     const condition = new Condition()
-    condition.setValue(conditionByteString)
+    condition.setValue(conditionBytes)
 
     // WHEN it is serialized.
     const serialized = Serializer.conditionToJSON(condition)
 
     // THEN the result is as expected.
-    assert.equal(serialized, conditionByteString)
+    assert.equal(serialized, Utils.toHex(conditionBytes))
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -42,6 +42,7 @@ import {
   Expiration,
   OfferSequence,
   Owner,
+  Condition,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1390,7 +1391,7 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized
     const serialized = Serializer.destinationToJSON(destination)
-    
+
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
@@ -1435,11 +1436,11 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized.
     const serialized = Serializer.checkCancelToJSON(checkCancel)
-    
+
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Serializes a SendMax', function (): void {
     // GIVEN a SendMax.
     const xrpDropsAmount = makeXrpDropsAmount('10')
@@ -1585,5 +1586,19 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)
+  })
+
+  it('Serializes a Condition', function (): void {
+    // GIVEN a Condition.
+    const conditionByteString =
+      'A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100'
+    const condition = new Condition()
+    condition.setValue(conditionByteString)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.conditionToJSON(condition)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, conditionByteString)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for CancelAfter and FinishAfter protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `CancelAfter` + `FinishAfter`, and adds associated unit tests. 

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 