### PR TITLE
Serialize Paths in Payments

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -96,6 +96,7 @@ export interface PaymentJSON {
   Destination: DestinationJSON
   DestinationTag?: DestinationTagJSON
   InvoiceID?: InvoiceIdJSON
+  Paths: PathJSON[]
   SendMax?: SendMaxJSON
   TransactionType: 'Payment'
 }
@@ -308,6 +309,13 @@ const serializer = {
     const sendMax = payment.getSendMax()
     if (sendMax !== undefined) {
       json.SendMax = this.sendMaxToJSON(sendMax)
+    }
+
+    const pathList = payment.getPathsList()
+    if (pathList.length > 0) {
+      json.Paths = pathList.map((path) => {
+        return this.pathToJSON(path)
+      })
     }
 
     return json

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -92,9 +92,10 @@ export interface EscrowCancelJSON {
 
 export interface PaymentJSON {
   Amount: AmountJSON
-  Destination: string
+  DeliverMin?: DeliverMinJSON
+  Destination: DestinationJSON
   DestinationTag?: DestinationTagJSON
-  InvoiceID?: string
+  InvoiceID?: InvoiceIdJSON
   TransactionType: 'Payment'
 }
 
@@ -296,6 +297,11 @@ const serializer = {
     const invoiceId = payment.getInvoiceId()
     if (invoiceId !== undefined) {
       json.InvoiceID = this.invoiceIdToJSON(invoiceId)
+    }
+
+    const deliverMin = payment.getDeliverMin()
+    if (deliverMin !== undefined) {
+      json.DeliverMin = this.deliverMinToJSON(deliverMin)
     }
 
     return json

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -96,6 +96,7 @@ export interface PaymentJSON {
   Destination: DestinationJSON
   DestinationTag?: DestinationTagJSON
   InvoiceID?: InvoiceIdJSON
+  SendMax?: SendMaxJSON
   TransactionType: 'Payment'
 }
 
@@ -302,6 +303,11 @@ const serializer = {
     const deliverMin = payment.getDeliverMin()
     if (deliverMin !== undefined) {
       json.DeliverMin = this.deliverMinToJSON(deliverMin)
+    }
+
+    const sendMax = payment.getSendMax()
+    if (sendMax !== undefined) {
+      json.SendMax = this.sendMaxToJSON(sendMax)
     }
 
     return json

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -94,6 +94,7 @@ export interface PaymentJSON {
   Amount: AmountJSON
   Destination: string
   DestinationTag?: DestinationTagJSON
+  InvoiceID?: string
   TransactionType: 'Payment'
 }
 
@@ -290,6 +291,11 @@ const serializer = {
     const destinationTag = payment.getDestinationTag()
     if (destinationTag !== undefined) {
       json.DestinationTag = this.destinationTagToJSON(destinationTag)
+    }
+
+    const invoiceId = payment.getInvoiceId()
+    if (invoiceId !== undefined) {
+      json.InvoiceID = this.invoiceIdToJSON(invoiceId)
     }
 
     return json

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1721,12 +1721,18 @@ describe('serializer', function (): void {
     const deliverMin = new DeliverMin()
     deliverMin.setValue(deliverMinAmount)
 
+    const sendMaxAmount = makeXrpCurrencyAmount('13')
+
+    const sendMax = new SendMax()
+    sendMax.setValue(sendMaxAmount)
+
     const payment = new Payment()
     payment.setAmount(amount)
     payment.setDeliverMin(deliverMin)
     payment.setDestination(destination)
     payment.setDestinationTag(destinationTag)
     payment.setInvoiceId(invoiceId)
+    payment.setSendMax(sendMax)
 
     // WHEN it is serialized.
     const serialized = Serializer.paymentToJSON(payment)
@@ -1738,6 +1744,7 @@ describe('serializer', function (): void {
       Destination: Serializer.destinationToJSON(destination)!,
       DestinationTag: Serializer.destinationTagToJSON(destinationTag),
       InvoiceID: Serializer.invoiceIdToJSON(invoiceId),
+      SendMax: Serializer.sendMaxToJSON(sendMax),
       TransactionType: 'Payment',
     }
     assert.deepEqual(serialized, expected)

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -441,6 +441,21 @@ function makeIssuedCurrencyAmount(
   return issuedCurrency
 }
 
+/**
+ * Returns a CurrencyAmount representing drops of XRP.
+ *
+ * @param drops - The number of drops to represent.
+ * @returns A CurrencyAmount representing the input.
+ */
+function makeXrpCurrencyAmount(drops: string): CurrencyAmount {
+  const xrpDropsAmount = makeXrpDropsAmount(drops)
+
+  const currencyAmount = new CurrencyAmount()
+  currencyAmount.setXrpAmount(xrpDropsAmount)
+
+  return currencyAmount
+}
+
 describe('serializer', function (): void {
   it('serializes a payment in XRP from a classic address', function (): void {
     // GIVEN a transaction which represents a payment denominated in XRP.
@@ -1687,13 +1702,10 @@ describe('serializer', function (): void {
   it('Serializes a Payment with all fields set', function (): void {
     // GIVEN a Payment with all mandatory fields.
     // TODO(keefertaylor): Add additional fields here when they are implemented.
-    const xrpAmount = makeXrpDropsAmount('10')
-
-    const currencyAmount = new CurrencyAmount()
-    currencyAmount.setXrpAmount(xrpAmount)
+    const transactionAmount = makeXrpCurrencyAmount('10')
 
     const amount = new Amount()
-    amount.setValue(currencyAmount)
+    amount.setValue(transactionAmount)
 
     const destination = new Destination()
     destination.setValue(testAccountAddress)
@@ -1704,8 +1716,14 @@ describe('serializer', function (): void {
     const invoiceId = new InvoiceID()
     invoiceId.setValue(new Uint8Array([1, 2, 3, 4]))
 
+    const deliverMinAmount = makeXrpCurrencyAmount('12')
+
+    const deliverMin = new DeliverMin()
+    deliverMin.setValue(deliverMinAmount)
+
     const payment = new Payment()
     payment.setAmount(amount)
+    payment.setDeliverMin(deliverMin)
     payment.setDestination(destination)
     payment.setDestinationTag(destinationTag)
     payment.setInvoiceId(invoiceId)
@@ -1716,6 +1734,7 @@ describe('serializer', function (): void {
     // THEN the result is in the expected form.
     const expected: PaymentJSON = {
       Amount: Serializer.amountToJSON(amount)!,
+      DeliverMin: Serializer.deliverMinToJSON(deliverMin),
       Destination: Serializer.destinationToJSON(destination)!,
       DestinationTag: Serializer.destinationTagToJSON(destinationTag),
       InvoiceID: Serializer.invoiceIdToJSON(invoiceId),

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1701,10 +1701,14 @@ describe('serializer', function (): void {
     const destinationTag = new DestinationTag()
     destinationTag.setValue(11)
 
+    const invoiceId = new InvoiceID()
+    invoiceId.setValue(new Uint8Array([1, 2, 3, 4]))
+
     const payment = new Payment()
     payment.setAmount(amount)
     payment.setDestination(destination)
     payment.setDestinationTag(destinationTag)
+    payment.setInvoiceId(invoiceId)
 
     // WHEN it is serialized.
     const serialized = Serializer.paymentToJSON(payment)
@@ -1714,6 +1718,7 @@ describe('serializer', function (): void {
       Amount: Serializer.amountToJSON(amount)!,
       Destination: Serializer.destinationToJSON(destination)!,
       DestinationTag: Serializer.destinationTagToJSON(destinationTag),
+      InvoiceID: Serializer.invoiceIdToJSON(invoiceId),
       TransactionType: 'Payment',
     }
     assert.deepEqual(serialized, expected)

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -59,6 +59,7 @@ import Serializer, {
   AccountSetJSON,
   DepositPreauthJSON,
   TransactionJSON,
+  PaymentJSON,
 } from '../../src/XRP/serializer'
 import XrpUtils from '../../src/XRP/xrp-utils'
 
@@ -557,8 +558,7 @@ describe('serializer', function (): void {
     const expectedJSON: TransactionJSON = {
       Account: accountClassicAddress,
       Amount: value.toString(),
-      Destination: destinationClassicAddress,
-      DestinationTag: tag,
+      Destination: destinationXAddressWithTag,
       Fee: fee.toString(),
       LastLedgerSequence: lastLedgerSequenceValue,
       Sequence: sequenceValue,
@@ -587,7 +587,7 @@ describe('serializer', function (): void {
     const expectedJSON: TransactionJSON = {
       Account: accountClassicAddress,
       Amount: value.toString(),
-      Destination: destinationClassicAddress,
+      Destination: destinationXAddressWithoutTag,
       Fee: fee.toString(),
       LastLedgerSequence: lastLedgerSequenceValue,
       Sequence: sequenceValue,
@@ -630,7 +630,7 @@ describe('serializer', function (): void {
     const expectedJSON: TransactionJSON = {
       Account: accountClassicAddress,
       Amount: value.toString(),
-      Destination: destinationClassicAddress,
+      Destination: destinationXAddressWithoutTag,
       Fee: fee.toString(),
       LastLedgerSequence: lastLedgerSequenceValue,
       Sequence: sequenceValue,
@@ -1465,11 +1465,11 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized.
     const serialized = Serializer.checkCancelToJSON(checkCancel)
-    
+
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Serializes a SendMax', function (): void {
     // GIVEN a SendMax.
     const xrpDropsAmount = makeXrpDropsAmount('10')
@@ -1650,6 +1650,99 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized.
     const serialized = Serializer.escrowCancelToJSON(escrowCancel)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Serializes a Payment with only mandatory fields set', function (): void {
+    // GIVEN a Payment with only mandatory fields.
+    const xrpAmount = makeXrpDropsAmount('10')
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(xrpAmount)
+
+    const amount = new Amount()
+    amount.setValue(currencyAmount)
+
+    const destination = new Destination()
+    destination.setValue(testAccountAddress)
+
+    const payment = new Payment()
+    payment.setAmount(amount)
+    payment.setDestination(destination)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentToJSON(payment)
+
+    // THEN the result is in the expected form.
+    const expected: PaymentJSON = {
+      Amount: Serializer.amountToJSON(amount)!,
+      Destination: Serializer.destinationToJSON(destination)!,
+      TransactionType: 'Payment',
+    }
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Serializes a Payment with all fields set', function (): void {
+    // GIVEN a Payment with all mandatory fields.
+    // TODO(keefertaylor): Add additional fields here when they are implemented.
+    const xrpAmount = makeXrpDropsAmount('10')
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(xrpAmount)
+
+    const amount = new Amount()
+    amount.setValue(currencyAmount)
+
+    const destination = new Destination()
+    destination.setValue(testAccountAddress)
+
+    const destinationTag = new DestinationTag()
+    destinationTag.setValue(11)
+
+    const payment = new Payment()
+    payment.setAmount(amount)
+    payment.setDestination(destination)
+    payment.setDestinationTag(destinationTag)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentToJSON(payment)
+
+    // THEN the result is in the expected form.
+    const expected: PaymentJSON = {
+      Amount: Serializer.amountToJSON(amount)!,
+      Destination: Serializer.destinationToJSON(destination)!,
+      DestinationTag: Serializer.destinationTagToJSON(destinationTag),
+      TransactionType: 'Payment',
+    }
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Fails to serialize a malformed Payment', function (): void {
+    // GIVEN a malformed Payment.
+    const payment = new Payment()
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentToJSON(payment)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Fails to serialize a payment with a malformed mandatory field', function (): void {
+    // GIVEN a Payment with a malformed amount field.
+    const amount = new Amount()
+
+    const destination = new Destination()
+    destination.setValue(testAccountAddress)
+
+    const payment = new Payment()
+    payment.setAmount(amount)
+    payment.setDestination(destination)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentToJSON(payment)
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1856,7 +1856,7 @@ describe('serializer', function (): void {
   })
 
   it('Serializes a Payment with all fields set', function (): void {
-    // GIVEN a Payment with all mandatory fields.
+    // GIVEN a Payment with all fields.
     const transactionAmount = makeXrpCurrencyAmount('10')
 
     const amount = new Amount()


### PR DESCRIPTION
## High Level Overview of Change

Serialize `Paths` in `Payment` transactions if it is set. 

### Context of Change

Payment did not serialize all fields previously. This PR wires an additional field. 

Docs: https://xrpl.org/payment.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - Tests updated
