### PR TITLE
Serialization for EscrowFinish

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -467,7 +467,19 @@ const serializer = {
     return json
   },
 
-  escrowFinishToJSON(_escrowFinish: EscrowFinish): EscrowFinishJSON | undefined {
+  /**
+   * Convert an EscrowFinish to a JSON representation.
+   *
+   * @param escrowFinish - The EscrowFinish to convert.
+   * @returns The EscrowFinish as JSON.
+   */
+  escrowFinishToJSON(escrowFinish: EscrowFinish): EscrowFinishJSON | undefined {
+    const owner = escrowFinish.getOwner();
+    const offerSequence = escrowFinish.getOfferSequence();
+    if (owner === undefined || offerSequence === undefined) {
+      return undefined
+    }
+
     return undefined
   },
 

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -833,6 +833,7 @@ const serializer = {
     }
     return this.accountAddressToJSON(accountAddress)
   },
+
   /**
    * Convert a CheckID to a JSON representation.
    *

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -53,6 +53,7 @@ import {
   CheckCancel,
   EscrowCancel,
   EscrowCreate,
+  EscrowFinish
 } from './generated/org/xrpl/rpc/v1/transaction_pb'
 import XrpUtils from './xrp-utils'
 
@@ -105,6 +106,10 @@ export interface EscrowCreateJSON {
   TransactionType: 'EscrowCreate'
 }
 
+export interface EscrowFinishJSON {
+  TransactionType: 'EscrowFinish'
+}
+
 export interface PaymentJSON {
   Amount: AmountJSON
   Destination: string
@@ -123,6 +128,7 @@ type TransactionDataJSON =
   | DepositPreauthJSON
   | EscrowCancelJSON
   | EscrowCreateJSON
+  | EscrowFinishJSON
   | PaymentJSON
 
 /**
@@ -133,6 +139,7 @@ type CheckCancelTransactionJSON = BaseTransactionJSON & CheckCancelJSON
 type DepositPreauthTransactionJSON = BaseTransactionJSON & DepositPreauthJSON
 type EscrowCancelTransactionJSON = BaseTransactionJSON & EscrowCancelJSON
 type EscrowCreateTransactionJSON = BaseTransactionJSON & EscrowCreateJSON
+type EscrowFinishTransactionJSON = BaseTransactionJSON & EscrowFinishJSON
 type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
 
 /**
@@ -144,6 +151,7 @@ export type TransactionJSON =
   | DepositPreauthTransactionJSON
   | EscrowCancelTransactionJSON
   | EscrowCreateTransactionJSON
+  | EscrowFinishTransactionJSON
   | PaymentTransactionJSON
 
 /**

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -37,6 +37,7 @@ import {
   Account,
   OfferSequence,
   Owner,
+  Condition,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -182,6 +183,7 @@ type PathJSON = PathElementJSON[]
 type CurrencyJSON = string
 type OfferSequenceJSON = number
 type OwnerJSON = string
+type ConditionJSON = string
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -355,9 +357,9 @@ const serializer = {
    * @returns The Owner as JSON.
    */
   ownerToJSON(owner: Owner): OwnerJSON | undefined {
-    const accountAddress = owner.getValue();
+    const accountAddress = owner.getValue()
     if (accountAddress === undefined) {
-      return undefined;
+      return undefined
     }
 
     return this.accountAddressToJSON(accountAddress)
@@ -831,7 +833,7 @@ const serializer = {
     }
     return this.accountAddressToJSON(accountAddress)
   },
-    
+
   /**
    * Convert a CheckID to a JSON representation.
    *
@@ -858,8 +860,8 @@ const serializer = {
       CheckID: this.checkIDToJSON(checkId),
     }
   },
-    
-  /**    
+
+  /**
    * Convert a SendMax to a JSON respresentation.
    *
    * @param sendMax - The SendMax to convert.
@@ -916,6 +918,16 @@ const serializer = {
   accountToJSON(account: Account): AccountJSON | undefined {
     // TODO(keefertaylor): Use accountAddressToJSON() here when supported.
     return account.getValue()?.getAddress()
+  },
+
+  /**
+   * Convert a Condition to a JSON representation.
+   *
+   * @param condition - The Condition to convert.
+   * @returns The Condition as JSON.
+   */
+  conditionToJSON(condition: Condition): ConditionJSON {
+    return condition.getValue_asB64()
   },
 }
 

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -51,6 +51,7 @@ import {
   DepositPreauth,
   CheckCancel,
   EscrowCancel,
+  EscrowCreate,
 } from './generated/org/xrpl/rpc/v1/transaction_pb'
 import XrpUtils from './xrp-utils'
 
@@ -91,6 +92,13 @@ export interface EscrowCancelJSON {
   OfferSequence: OfferSequenceJSON
   Owner: OwnerJSON
   TransactionType: 'EscrowCancel'
+}
+
+export interface EscrowCreateJSON {
+  CancelAfter?: CancelAfterJSON
+  Condition?: ConditionJSON
+  FinishAfter?: FinishAfterJSON
+  TransactionType: 'EscrowCreate'
 }
 
 export interface PaymentJSON {
@@ -393,6 +401,32 @@ const serializer = {
       Owner: ownerJSON,
       TransactionType: 'EscrowCancel',
     }
+  },
+
+  /**
+   * Convert an EscrowCreate to a JSON representation.
+   *
+   * @param escrowCreate - The EscrowCreate to convert.
+   * @returns The EscrowCreate as JSON.
+   */
+  escrowCreateToJSON(escrowCreate: EscrowCreate): EscrowCreateJSON | undefined {
+    const json: EscrowCreateJSON = { TransactionType: 'EscrowCreate' }
+    const cancelAfter = escrowCreate.getCancelAfter()
+    if (cancelAfter !== undefined) {
+      json.CancelAfter = this.cancelAfterToJSON(cancelAfter)
+    }
+
+    const condition = escrowCreate.getCondition()
+    if (condition !== undefined) {
+      json.Condition = this.conditionToJSON(condition)
+    }
+
+    const finishAfter = escrowCreate.getFinishAfter()
+    if (finishAfter !== undefined) {
+      json.FinishAfter = this.finishAfterToJSON(finishAfter)
+    }
+
+    return json
   },
 
   /**

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -107,6 +107,8 @@ export interface EscrowCreateJSON {
 }
 
 export interface EscrowFinishJSON {
+  OfferSequence: OfferSequenceJSON,
+  Owner: OwnerJSON,
   TransactionType: 'EscrowFinish'
 }
 
@@ -474,13 +476,24 @@ const serializer = {
    * @returns The EscrowFinish as JSON.
    */
   escrowFinishToJSON(escrowFinish: EscrowFinish): EscrowFinishJSON | undefined {
-    const owner = escrowFinish.getOwner();
     const offerSequence = escrowFinish.getOfferSequence();
+    const owner = escrowFinish.getOwner();
     if (owner === undefined || offerSequence === undefined) {
       return undefined
     }
 
-    return undefined
+    const ownerJSON = this.ownerToJSON(owner)
+    if (!ownerJSON) {
+      return undefined
+    }
+
+    const json: EscrowFinishJSON = {
+      OfferSequence: this.offerSequenceToJSON(offerSequence),
+      Owner: ownerJSON,
+      TransactionType: 'EscrowFinish'
+    }
+
+    return json
   },
 
   /**

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -41,7 +41,7 @@ import {
   Owner,
   Condition,
   CancelAfter,
-  FinishAfter
+  FinishAfter,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -969,22 +969,22 @@ const serializer = {
   /**
    * Convert a CancelAfter to a JSON representation.
    *
-   * @param condition - The CancelAfter to convert.
+   * @param cancelAfter - The CancelAfter to convert.
    * @returns The CancelAfter as JSON.
    */
   cancelAfterToJSON(cancelAfter: CancelAfter): CancelAfterJSON {
-    return cancelAfter.getValue();
+    return cancelAfter.getValue()
   },
 
   /**
    * Convert a FinishAfter to a JSON representation.
    *
-   * @param condition - The FinshAfter to convert.
+   * @param finishAfter - The FinshAfter to convert.
    * @returns The FinishAfter as JSON.
    */
   finishAfterToJSON(finishAfter: FinishAfter): FinishAfterJSON {
-    return finishAfter.getValue();
-  }
+    return finishAfter.getValue()
+  },
 }
 
 export default serializer

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -927,7 +927,7 @@ const serializer = {
    * @returns The Condition as JSON.
    */
   conditionToJSON(condition: Condition): ConditionJSON {
-    return condition.getValue_asB64()
+    return Utils.toHex(condition.getValue_asU8())
   },
 }
 

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -98,6 +98,8 @@ export interface EscrowCreateJSON {
   Amount: AmountJSON
   CancelAfter?: CancelAfterJSON
   Condition?: ConditionJSON
+  Destination: DestinationJSON
+  DestinationTag?: DestinationTagJSON
   FinishAfter?: FinishAfterJSON
   TransactionType: 'EscrowCreate'
 }
@@ -414,19 +416,22 @@ const serializer = {
    * @returns The EscrowCreate as JSON.
    */
   escrowCreateToJSON(escrowCreate: EscrowCreate): EscrowCreateJSON | undefined {
-    const amount = escrowCreate.getAmount();
-    if (amount === undefined) {
+    const amount = escrowCreate.getAmount()
+    const destination = escrowCreate.getDestination()
+    if (amount === undefined || destination === undefined) {
       return undefined
     }
 
-    const amountJSON = this.amountToJSON(amount)
-    if (amountJSON === undefined) {
+    const amountJson = this.amountToJSON(amount)
+    const destinationJson = this.destinationToJSON(destination)
+    if (amountJson === undefined || destinationJson === undefined) {
       return undefined
     }
 
-    const json: EscrowCreateJSON = { 
-      Amount: amountJSON,
-      TransactionType: 'EscrowCreate' 
+    const json: EscrowCreateJSON = {
+      Amount: amountJson,
+      Destination: destinationJson,
+      TransactionType: 'EscrowCreate',
     }
 
     const cancelAfter = escrowCreate.getCancelAfter()
@@ -437,6 +442,11 @@ const serializer = {
     const condition = escrowCreate.getCondition()
     if (condition !== undefined) {
       json.Condition = this.conditionToJSON(condition)
+    }
+
+    const destinationTag = escrowCreate.getDestinationTag()
+    if (destinationTag !== undefined) {
+      json.DestinationTag = this.destinationTagToJSON(destinationTag)
     }
 
     const finishAfter = escrowCreate.getFinishAfter()

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -42,6 +42,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  Fulfillment,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -206,6 +207,7 @@ type OwnerJSON = string
 type ConditionJSON = string
 type CancelAfterJSON = number
 type FinishAfterJSON = number
+type FulfillmentJSON = string
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -1041,12 +1043,21 @@ const serializer = {
   /**
    * Convert a FinishAfter to a JSON representation.
    *
-   * @param finishAfter - The FinshAfter to convert.
+   * @param finishAfter - The FinishAfter to convert.
    * @returns The FinishAfter as JSON.
    */
   finishAfterToJSON(finishAfter: FinishAfter): FinishAfterJSON {
     return finishAfter.getValue()
   },
+
+  /**
+   * Convert a Fulfillment to a JSON representation.
+   * 
+   * @param fulfillment - The Fulfillment to convert.
+   */
+  fulfillmentToJSON(fulfillment: Fulfillment): FulfillmentJSON {
+    return Utils.toHex(fulfillment.getValue_asU8())
+  }
 }
 
 export default serializer

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -95,6 +95,7 @@ export interface EscrowCancelJSON {
 }
 
 export interface EscrowCreateJSON {
+  Amount: AmountJSON
   CancelAfter?: CancelAfterJSON
   Condition?: ConditionJSON
   FinishAfter?: FinishAfterJSON
@@ -118,6 +119,7 @@ type TransactionDataJSON =
   | CheckCancelJSON
   | DepositPreauthJSON
   | EscrowCancelJSON
+  | EscrowCreateJSON
   | PaymentJSON
 
 /**
@@ -127,6 +129,7 @@ type AccountSetTransactionJSON = BaseTransactionJSON & AccountSetJSON
 type CheckCancelTransactionJSON = BaseTransactionJSON & CheckCancelJSON
 type DepositPreauthTransactionJSON = BaseTransactionJSON & DepositPreauthJSON
 type EscrowCancelTransactionJSON = BaseTransactionJSON & EscrowCancelJSON
+type EscrowCreateTransactionJSON = BaseTransactionJSON & EscrowCreateJSON
 type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
 
 /**
@@ -137,6 +140,7 @@ export type TransactionJSON =
   | CheckCancelTransactionJSON
   | DepositPreauthTransactionJSON
   | EscrowCancelTransactionJSON
+  | EscrowCreateTransactionJSON
   | PaymentTransactionJSON
 
 /**

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -414,7 +414,21 @@ const serializer = {
    * @returns The EscrowCreate as JSON.
    */
   escrowCreateToJSON(escrowCreate: EscrowCreate): EscrowCreateJSON | undefined {
-    const json: EscrowCreateJSON = { TransactionType: 'EscrowCreate' }
+    const amount = escrowCreate.getAmount();
+    if (amount === undefined) {
+      return undefined
+    }
+
+    const amountJSON = this.amountToJSON(amount)
+    if (amountJSON === undefined) {
+      return undefined
+    }
+
+    const json: EscrowCreateJSON = { 
+      Amount: amountJSON,
+      TransactionType: 'EscrowCreate' 
+    }
+
     const cancelAfter = escrowCreate.getCancelAfter()
     if (cancelAfter !== undefined) {
       json.CancelAfter = this.cancelAfterToJSON(cancelAfter)

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -467,6 +467,10 @@ const serializer = {
     return json
   },
 
+  escrowFinishToJSON(_escrowFinish: EscrowFinish): EscrowFinishJSON | undefined {
+    return undefined
+  },
+
   /**
    * Convert a AccountSet to a JSON representation.
    *

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -833,7 +833,6 @@ const serializer = {
     }
     return this.accountAddressToJSON(accountAddress)
   },
-
   /**
    * Convert a CheckID to a JSON representation.
    *

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -40,6 +40,8 @@ import {
   OfferSequence,
   Owner,
   Condition,
+  CancelAfter,
+  FinishAfter
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -188,6 +190,8 @@ type TakerGetsJSON = CurrencyAmountJSON
 type OfferSequenceJSON = number
 type OwnerJSON = string
 type ConditionJSON = string
+type CancelAfterJSON = number
+type FinishAfterJSON = number
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -961,6 +965,26 @@ const serializer = {
   conditionToJSON(condition: Condition): ConditionJSON {
     return Utils.toHex(condition.getValue_asU8())
   },
+
+  /**
+   * Convert a CancelAfter to a JSON representation.
+   *
+   * @param condition - The CancelAfter to convert.
+   * @returns The CancelAfter as JSON.
+   */
+  cancelAfterToJSON(cancelAfter: CancelAfter): CancelAfterJSON {
+    return cancelAfter.getValue();
+  },
+
+  /**
+   * Convert a FinishAfter to a JSON representation.
+   *
+   * @param condition - The FinshAfter to convert.
+   * @returns The FinishAfter as JSON.
+   */
+  finishAfterToJSON(finishAfter: FinishAfter): FinishAfterJSON {
+    return finishAfter.getValue();
+  }
 }
 
 export default serializer

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -107,6 +107,8 @@ export interface EscrowCreateJSON {
 }
 
 export interface EscrowFinishJSON {
+  Condition?: ConditionJSON
+  Fulfillment?: FulfillmentJSON
   OfferSequence: OfferSequenceJSON
   Owner: OwnerJSON
   TransactionType: 'EscrowFinish'
@@ -483,7 +485,7 @@ const serializer = {
     }
 
     const ownerJSON = this.ownerToJSON(owner)
-    if (!ownerJSON) {
+    if (ownerJSON === undefined) {
       return undefined
     }
 
@@ -491,6 +493,16 @@ const serializer = {
       OfferSequence: this.offerSequenceToJSON(offerSequence),
       Owner: ownerJSON,
       TransactionType: 'EscrowFinish',
+    }
+
+    const condition = escrowFinish.getCondition()
+    if (condition !== undefined) {
+      json.Condition = this.conditionToJSON(condition)
+    }
+
+    const fulfillment = escrowFinish.getFulfillment()
+    if (fulfillment !== undefined) {
+      json.Fulfillment = this.fulfillmentToJSON(fulfillment)
     }
 
     return json

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -40,11 +40,8 @@ import {
   OfferSequence,
   Owner,
   Condition,
-<<<<<<< HEAD
   CancelAfter,
   FinishAfter,
-=======
->>>>>>> 2dde9bfe8c68d8ae51f9064d69c859947e1c3e1a
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -193,11 +190,8 @@ type TakerGetsJSON = CurrencyAmountJSON
 type OfferSequenceJSON = number
 type OwnerJSON = string
 type ConditionJSON = string
-<<<<<<< HEAD
 type CancelAfterJSON = number
 type FinishAfterJSON = number
-=======
->>>>>>> 2dde9bfe8c68d8ae51f9064d69c859947e1c3e1a
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -53,7 +53,7 @@ import {
   CheckCancel,
   EscrowCancel,
   EscrowCreate,
-  EscrowFinish
+  EscrowFinish,
 } from './generated/org/xrpl/rpc/v1/transaction_pb'
 import XrpUtils from './xrp-utils'
 
@@ -107,8 +107,8 @@ export interface EscrowCreateJSON {
 }
 
 export interface EscrowFinishJSON {
-  OfferSequence: OfferSequenceJSON,
-  Owner: OwnerJSON,
+  OfferSequence: OfferSequenceJSON
+  Owner: OwnerJSON
   TransactionType: 'EscrowFinish'
 }
 
@@ -476,8 +476,8 @@ const serializer = {
    * @returns The EscrowFinish as JSON.
    */
   escrowFinishToJSON(escrowFinish: EscrowFinish): EscrowFinishJSON | undefined {
-    const offerSequence = escrowFinish.getOfferSequence();
-    const owner = escrowFinish.getOwner();
+    const offerSequence = escrowFinish.getOfferSequence()
+    const owner = escrowFinish.getOwner()
     if (owner === undefined || offerSequence === undefined) {
       return undefined
     }
@@ -490,7 +490,7 @@ const serializer = {
     const json: EscrowFinishJSON = {
       OfferSequence: this.offerSequenceToJSON(offerSequence),
       Owner: ownerJSON,
-      TransactionType: 'EscrowFinish'
+      TransactionType: 'EscrowFinish',
     }
 
     return json

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -1052,12 +1052,13 @@ const serializer = {
 
   /**
    * Convert a Fulfillment to a JSON representation.
-   * 
+   *
    * @param fulfillment - The Fulfillment to convert.
+   * @returns The Fulfillment as JSON.
    */
   fulfillmentToJSON(fulfillment: Fulfillment): FulfillmentJSON {
     return Utils.toHex(fulfillment.getValue_asU8())
-  }
+  },
 }
 
 export default serializer

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1793,7 +1793,7 @@ describe('serializer', function (): void {
   })
 
   it('Serializes an EscrowCreate with required fields', function (): void {
-    // GIVEN an EscrowCreate with all mandatory fields set.
+    // GIVEN an EscrowCreate with required fields set.
     const xrpAmount = makeXrpDropsAmount('10')
 
     const currencyAmount = new CurrencyAmount()
@@ -1822,6 +1822,57 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized, expected)
   })
 
+  it('Serializes an EscrowCreate with all fields', function (): void {
+    // GIVEN an EscrowCreate with all fields set.
+    const xrpAmount = makeXrpDropsAmount('10')
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(xrpAmount)
+
+    const amount = new Amount()
+    amount.setValue(currencyAmount)
+
+    const destination = new Destination()
+    destination.setValue(testAccountAddress)
+
+    const destinationTag = new DestinationTag()
+    destinationTag.setValue(11)
+
+    const cancelAfter = new CancelAfter()
+    cancelAfter.setValue(1)
+
+    const conditionBytes = new Uint8Array([0, 1, 2, 3])
+    const condition = new Condition()
+    condition.setValue(conditionBytes)
+
+    const finishAfter = new FinishAfter()
+    finishAfter.setValue(2)
+
+    const escrowCreate = new EscrowCreate()
+    escrowCreate.setAmount(amount)
+    escrowCreate.setDestination(destination)
+    escrowCreate.setDestinationTag(destinationTag)
+    escrowCreate.setCancelAfter(cancelAfter)
+    escrowCreate.setCondition(condition)
+    escrowCreate.setFinishAfter(finishAfter)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.escrowCreateToJSON(escrowCreate)
+
+    const expected: EscrowCreateJSON = {
+      Amount: Serializer.amountToJSON(amount)!,
+      Destination: Serializer.destinationToJSON(destination)!,
+      DestinationTag: Serializer.destinationTagToJSON(destinationTag),
+      CancelAfter: Serializer.cancelAfterToJSON(cancelAfter),
+      Condition: Serializer.conditionToJSON(condition),
+      FinishAfter: Serializer.finishAfterToJSON(finishAfter),
+      TransactionType: 'EscrowCreate',
+    }
+
+    // THEN the result is as expected.
+    assert.deepEqual(serialized, expected)
+  })
+
   it('Fails to serialize an EscrowCreate missing an amount', function (): void {
     // GIVEN an EscrowCreate that's missing an amount.
     const destination = new Destination()
@@ -1838,7 +1889,7 @@ describe('serializer', function (): void {
   })
 
   it('Fails to serialize an EscrowCreate missing a destination', function (): void {
-    // GIVEN an EscrowCreat that's missing an amount.
+    // GIVEN an EscrowCreat that's missing a destination.
     const xrpAmount = makeXrpDropsAmount('10')
 
     const currencyAmount = new CurrencyAmount()
@@ -1849,6 +1900,22 @@ describe('serializer', function (): void {
 
     const escrowCreate = new EscrowCreate()
     escrowCreate.setAmount(amount)
+
+    // WHEN the EscrowCreate is serialized.
+    const serialized = Serializer.escrowCreateToJSON(escrowCreate)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Fails to serialize an EscrowCreate with a malformed amount and destination', function (): void {
+    // GIVEN an EscrowCreate that has a malformed amount and destination.
+    const amount = new Amount()
+    const destination = new Destination()
+
+    const escrowCreate = new EscrowCreate()
+    escrowCreate.setAmount(amount)
+    escrowCreate.setDestination(destination)
 
     // WHEN the EscrowCreate is serialized.
     const serialized = Serializer.escrowCreateToJSON(escrowCreate)

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -47,6 +47,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  Fulfillment,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1922,5 +1923,18 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)
+  })
+
+  it('Serializes a Fulfilment', function (): void {
+    // GIVEN a Fulfillment with some bytes.
+    const fulfillmentBytes = new Uint8Array([0, 1, 2, 3])
+    const fulfillment = new Fulfillment()
+    fulfillment.setValue(fulfillmentBytes)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.conditionToJSON(fulfillment)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, Utils.toHex(fulfillmentBytes))
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1925,7 +1925,7 @@ describe('serializer', function (): void {
     assert.isUndefined(serialized)
   })
 
-  it('Serializes a Fulfilment', function (): void {
+  it('Serializes a Fulfillment', function (): void {
     // GIVEN a Fulfillment with some bytes.
     const fulfillmentBytes = new Uint8Array([0, 1, 2, 3])
     const fulfillment = new Fulfillment()

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -16,6 +16,7 @@ import {
   IssuedCurrencyAmount,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/amount_pb'
 import {
+  CancelAfter,
   Account,
   Amount,
   Destination,
@@ -1760,5 +1761,31 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)
+  })
+
+  it('Serializes a CancelAfter', function (): void {
+    // GIVEN a CancelAfter.
+    const cancelAfterTime = 533257958
+    const cancelAfter = new CancelAfter()
+    cancelAfter.setValue(cancelAfterTime)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.cancelAfterToJSON(cancelAfter)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, cancelAfterTime)
+  })
+
+  it('Serializes a FinishAfter', function (): void {
+    // GIVEN a FinishAfter.
+    const finishAfterTime = 5331715585
+    const finishAfter = new CancelAfter()
+    finishAfter.setValue(finishAfterTime)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.cancelAfterToJSON(finishAfter)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, finishAfterTime)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1932,7 +1932,7 @@ describe('serializer', function (): void {
     fulfillment.setValue(fulfillmentBytes)
 
     // WHEN it is serialized.
-    const serialized = Serializer.conditionToJSON(fulfillment)
+    const serialized = Serializer.fulfillmentToJSON(fulfillment)
 
     // THEN the result is as expected.
     assert.equal(serialized, Utils.toHex(fulfillmentBytes))

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -16,7 +16,6 @@ import {
   IssuedCurrencyAmount,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/amount_pb'
 import {
-  CancelAfter,
   Account,
   Amount,
   Destination,
@@ -46,6 +45,8 @@ import {
   OfferSequence,
   Owner,
   Condition,
+  CancelAfter,
+  FinishAfter,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1779,11 +1780,11 @@ describe('serializer', function (): void {
   it('Serializes a FinishAfter', function (): void {
     // GIVEN a FinishAfter.
     const finishAfterTime = 5331715585
-    const finishAfter = new CancelAfter()
+    const finishAfter = new FinishAfter()
     finishAfter.setValue(finishAfterTime)
 
     // WHEN it is serialized.
-    const serialized = Serializer.cancelAfterToJSON(finishAfter)
+    const serialized = Serializer.finishAfterToJSON(finishAfter)
 
     // THEN the result is as expected.
     assert.equal(serialized, finishAfterTime)

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2378,7 +2378,7 @@ describe('serializer', function (): void {
     const owner = new Owner()
 
     const escrowFinish = new EscrowFinish()
-    escrowFinish.setOfferSequence()
+    escrowFinish.setOfferSequence(offerSequence)
     escrowFinish.setOwner(owner)
 
     // WHEN it is serialized.

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1589,16 +1589,15 @@ describe('serializer', function (): void {
   })
 
   it('Serializes a Condition', function (): void {
-    // GIVEN a Condition.
-    const conditionByteString =
-      'A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100'
+    // GIVEN a Condition with some bytes.
+    const conditionBytes = new Uint8Array([0, 1, 2, 3])
     const condition = new Condition()
-    condition.setValue(conditionByteString)
+    condition.setValue(conditionBytes)
 
     // WHEN it is serialized.
     const serialized = Serializer.conditionToJSON(condition)
 
     // THEN the result is as expected.
-    assert.equal(serialized, conditionByteString)
+    assert.equal(serialized, Utils.toHex(conditionBytes))
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -56,9 +56,11 @@ import {
   AccountSet,
   CheckCancel,
   EscrowCancel,
+  EscrowCreate,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer, {
   EscrowCancelJSON,
+  EscrowCreateJSON,
   AccountSetJSON,
   DepositPreauthJSON,
   TransactionJSON,
@@ -1788,5 +1790,33 @@ describe('serializer', function (): void {
 
     // THEN the result is as expected.
     assert.equal(serialized, finishAfterTime)
+  })
+
+  it('Serializes an EscrowCreate with required fields', function (): void {
+    // GIVEN an EscrowCreate with all mandatory fields set.
+    const xrpAmount = makeXrpDropsAmount('10')
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(xrpAmount)
+
+    const amount = new Amount()
+    amount.setValue(currencyAmount)
+
+    const destination = new Destination()
+    destination.setValue(testAccountAddress)
+
+    const escrowCreate = new EscrowCreate()
+    escrowCreate.setAmount(amount)
+    escrowCreate.setDestination(destination)
+
+    const serialized = Serializer.escrowCreateToJSON(escrowCreate)
+
+    const expected: EscrowCreateJSON = {
+      Amount: Serializer.amountToJSON(amount)!,
+      Destination: Serializer.destinationToJSON(destination)!,
+      TransactionType: 'EscrowCreate',
+    }
+
+    assert.deepEqual(serialized, expected)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -42,6 +42,7 @@ import {
   Expiration,
   OfferSequence,
   Owner,
+  Condition,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1390,7 +1391,7 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized
     const serialized = Serializer.destinationToJSON(destination)
-    
+
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
@@ -1435,11 +1436,11 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized.
     const serialized = Serializer.checkCancelToJSON(checkCancel)
-    
+
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Serializes a SendMax', function (): void {
     // GIVEN a SendMax.
     const xrpDropsAmount = makeXrpDropsAmount('10')
@@ -1585,5 +1586,19 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)
+  })
+
+  it('Serializes a Condition', function (): void {
+    // GIVEN a Condition.
+    const conditionByteString =
+      'A0258020E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855810100'
+    const condition = new Condition()
+    condition.setValue(conditionByteString)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.conditionToJSON(condition)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, conditionByteString)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -58,10 +58,12 @@ import {
   CheckCancel,
   EscrowCancel,
   EscrowCreate,
+  EscrowFinish,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer, {
   EscrowCancelJSON,
   EscrowCreateJSON,
+  EscrowFinishJSON,
   AccountSetJSON,
   DepositPreauthJSON,
   TransactionJSON,
@@ -1936,5 +1938,30 @@ describe('serializer', function (): void {
 
     // THEN the result is as expected.
     assert.equal(serialized, Utils.toHex(fulfillmentBytes))
+  })
+
+  it('Serializes an EscrowFinish with required fields', function (): void {
+    // GIVEN an EscrowFinish with required fields.
+    const offerSequence = new OfferSequence()
+    offerSequence.setValue(offerSequenceNumber)
+
+    const owner = new Owner()
+    owner.setValue(testAccountAddress)
+
+    const escrowFinish = new EscrowFinish()
+    escrowFinish.setOfferSequence(offerSequence)
+    escrowFinish.setOwner(owner)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.escrowFinishToJSON(escrowFinish)
+
+    // THEN the result is as expected.
+    const expected: EscrowFinishJSON = {
+      OfferSequence: Serializer.offerSequenceToJSON(offerSequence),
+      Owner: Serializer.ownerToJSON(owner)!,
+      TransactionType: 'EscrowFinish',
+    }
+
+    assert.deepEqual(serialized, expected)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1809,6 +1809,7 @@ describe('serializer', function (): void {
     escrowCreate.setAmount(amount)
     escrowCreate.setDestination(destination)
 
+    // WHEN it is serialized.
     const serialized = Serializer.escrowCreateToJSON(escrowCreate)
 
     const expected: EscrowCreateJSON = {
@@ -1817,6 +1818,42 @@ describe('serializer', function (): void {
       TransactionType: 'EscrowCreate',
     }
 
+    // THEN the result is as expected.
     assert.deepEqual(serialized, expected)
+  })
+
+  it('Fails to serialize an EscrowCreate missing an amount', function (): void {
+    // GIVEN an EscrowCreate that's missing an amount.
+    const destination = new Destination()
+    destination.setValue(testAccountAddress)
+
+    const escrowCreate = new EscrowCreate()
+    escrowCreate.setDestination(destination)
+
+    // WHEN the EscrowCreate is serialized.
+    const serialized = Serializer.escrowCreateToJSON(escrowCreate)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Fails to serialize an EscrowCreate missing a destination', function (): void {
+    // GIVEN an EscrowCreat that's missing an amount.
+    const xrpAmount = makeXrpDropsAmount('10')
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(xrpAmount)
+
+    const amount = new Amount()
+    amount.setValue(currencyAmount)
+
+    const escrowCreate = new EscrowCreate()
+    escrowCreate.setAmount(amount)
+
+    // WHEN the EscrowCreate is serialized.
+    const serialized = Serializer.escrowCreateToJSON(escrowCreate)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1964,4 +1964,70 @@ describe('serializer', function (): void {
 
     assert.deepEqual(serialized, expected)
   })
+
+  it('Serializes an EscrowFinish with all fields', function (): void {
+    // GIVEN an EscrowFinish with all fields.
+    const conditionBytes = new Uint8Array([0, 1, 2, 3])
+    const condition = new Condition()
+    condition.setValue(conditionBytes)
+
+    const fulfillmentBytes = new Uint8Array([0, 1, 2, 3])
+    const fulfillment = new Fulfillment()
+    fulfillment.setValue(fulfillmentBytes)
+
+    const offerSequence = new OfferSequence()
+    offerSequence.setValue(offerSequenceNumber)
+
+    const owner = new Owner()
+    owner.setValue(testAccountAddress)
+
+    const escrowFinish = new EscrowFinish()
+    escrowFinish.setCondition(condition)
+    escrowFinish.setFulfillment(fulfillment)
+    escrowFinish.setOfferSequence(offerSequence)
+    escrowFinish.setOwner(owner)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.escrowFinishToJSON(escrowFinish)
+
+    // THEN the result is as expected.
+    const expected: EscrowFinishJSON = {
+      Condition: Serializer.conditionToJSON(condition),
+      Fulfillment: Serializer.fulfillmentToJSON(fulfillment),
+      OfferSequence: Serializer.offerSequenceToJSON(offerSequence),
+      Owner: Serializer.ownerToJSON(owner)!,
+      TransactionType: 'EscrowFinish',
+    }
+
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Fails to serialize an EscrowFinish missing required fields', function (): void {
+    // GIVEN an EscrowFinish that's missing required fields.
+    const escrowFinish = new EscrowFinish()
+
+    // WHEN it is serialized.
+    const serialized = Serializer.escrowFinishToJSON(escrowFinish)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Fails to serialize an EscrowFinish with a malformed owner', function (): void {
+    // GIVEN an EscrowCancel with a malformed owner.
+    const offerSequence = new OfferSequence()
+    offerSequence.setValue(offerSequenceNumber)
+
+    const owner = new Owner()
+
+    const escrowFinish = new EscrowFinish()
+    escrowFinish.setOfferSequence()
+    escrowFinish.setOwner(owner)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.escrowFinishToJSON(escrowFinish)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for EscrowFinish protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `EscrowFinish` and adds associated unit tests. 

Docs for `EscrowFinish`: https://xrpl.org/escrowfinish.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 