### PR TITLE
Serialize Channel Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -43,6 +43,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  Channel,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -199,6 +200,7 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type ChannelJSON = string
 type DeliverMinJSON = CurrencyAmountJSON
 type AccountAddressJSON = string
 type CheckIDJSON = string
@@ -1193,6 +1195,16 @@ const serializer = {
     }
 
     return json
+  },
+
+  /**
+   * Convert a Channel to a JSON representation.
+   *
+   * @param channel - The Channel to convert.
+   * @returns The Channel as JSON.
+   */
+  channelToJSON(channel: Channel): ChannelJSON {
+    return Utils.toHex(channel.getValue_asU8())
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -48,6 +48,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  Channel,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -2146,5 +2147,19 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined
     assert.isUndefined(serialized)
+  })
+
+  it('Serializes a Channel', function (): void {
+    // GIVEN a Channel.
+    const channelValue = new Uint8Array([1, 2, 3, 4])
+
+    const channel = new Channel()
+    channel.setValue(channelValue)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.channelToJSON(channel)
+
+    // THEN the output is the input encoded as hex.
+    assert.equal(serialized, Utils.toHex(channelValue))
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for Channel protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `Channel` and adds associated unit tests. 

Docs:  https://xrpl.org/paymentchannelclaim.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 