### PR TITLE
Serialize Balance Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -43,6 +43,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  Balance,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -199,6 +200,7 @@ interface IssuedCurrencyAmountJSON {
   issuer: string
 }
 
+type BalanceJSON = CurrencyAmountJSON
 type DeliverMinJSON = CurrencyAmountJSON
 type AccountAddressJSON = string
 type CheckIDJSON = string
@@ -1193,6 +1195,21 @@ const serializer = {
     }
 
     return json
+  },
+
+  /**
+   * Convert a Balance to a JSON representation.
+   *
+   * @param balance - The Balance to convert.
+   * @returns The Balance as JSON.
+   */
+  balanceToJSON(balance: Balance): BalanceJSON | undefined {
+    const currencyAmount = balance.getValue()
+    if (currencyAmount === undefined) {
+      return undefined
+    }
+
+    return this.currencyAmountToJSON(currencyAmount)
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -48,6 +48,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  Balance,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -2145,6 +2146,31 @@ describe('serializer', function (): void {
     const serialized = Serializer.checkCreateToJSON(checkCreate)
 
     // THEN the result is undefined
+    assert.isUndefined(serialized)
+  })
+
+  it('Serializes a Balance', function (): void {
+    // GIVEN a Balance.
+    const currencyAmount = makeXrpCurrencyAmount('10')
+
+    const balance = new Balance()
+    balance.setValue(currencyAmount)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.balanceToJSON(balance)
+
+    // THEN the output is the serialized versions of the input.
+    assert.equal(serialized, Serializer.currencyAmountToJSON(currencyAmount))
+  })
+
+  it('Fails to serialize a malformed Balance', function (): void {
+    // GIVEN a malformed Balance.
+    const balance = new Balance()
+
+    // WHEN it is serialized.
+    const serialized = Serializer.balanceToJSON(balance)
+
+    // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for Balance protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `Balance` and adds associated unit tests. 

Docs:  https://xrpl.org/paymentchannelclaim.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 