### PR TITLE
Serialize SettleDelay Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -43,6 +43,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  SettleDelay,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -250,6 +251,7 @@ type OwnerJSON = string
 type ConditionJSON = string
 type CancelAfterJSON = number
 type FinishAfterJSON = number
+type SettleDelayJSON = number
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -1255,6 +1257,16 @@ const serializer = {
     }
 
     return json
+  },
+
+  /**
+   * Convert a SettleDelay to a JSON representation.
+   *
+   * @param settleDelay - The SettleDelay to convert.
+   * @returns The SettleDelay as JSON.
+   */
+  settleDelayToJSON(settleDelay: SettleDelay): SettleDelayJSON {
+    return settleDelay.getValue()
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -48,6 +48,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  SettleDelay,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -2277,5 +2278,19 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)
+  })
+
+  it('Serializes a SettleDelay', function (): void {
+    // GIVEN a SettleDelay.
+    const settleDelayValue = 4
+
+    const settleDelay = new SettleDelay()
+    settleDelay.setValue(settleDelayValue)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.settleDelayToJSON(settleDelay)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, settleDelayValue)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for SettleDelay protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `SettleDelay` and adds associated unit tests. 

Docs:  https://xrpl.org/paymentchannelcreate.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 