### PR TITLE
Serialize RegularKey Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -43,6 +43,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  RegularKey,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -250,6 +251,7 @@ type OwnerJSON = string
 type ConditionJSON = string
 type CancelAfterJSON = number
 type FinishAfterJSON = number
+type RegularKeyJSON = AccountAddressJSON
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -1255,6 +1257,21 @@ const serializer = {
     }
 
     return json
+  },
+
+  /**
+   * Convert a RegularKey to a JSON representation.
+   *
+   * @param regularKey - The RegularKey to convert.
+   * @returns The RegularKey as JSON.
+   */
+  regularKeyToJSON(regularKey: RegularKey): RegularKeyJSON | undefined {
+    const accountAddress = regularKey.getValue()
+    if (accountAddress === undefined) {
+      return undefined
+    }
+
+    return this.accountAddressToJSON(accountAddress)
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -48,6 +48,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  RegularKey,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -2276,6 +2277,32 @@ describe('serializer', function (): void {
     const serialized = Serializer.escrowCreateToJSON(escrowCreate)
 
     // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Serializes a RegularKey', function (): void {
+    // GIVEN a RegularKey.
+    const regularKey = new RegularKey()
+    regularKey.setValue(testAccountAddress)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.regularKeyToJSON(regularKey)
+
+    // THEN the output is the serialized version of the input.
+    assert.equal(
+      serialized,
+      Serializer.accountAddressToJSON(testAccountAddress),
+    )
+  })
+
+  it('Fails to serialize a malformed RegularKey', function (): void {
+    // GIVEN a malformed RegularKey.
+    const regularKey = new RegularKey()
+
+    // WHEN it is serialized.
+    const serialized = Serializer.regularKeyToJSON(regularKey)
+
+    // THEN the output is the serialized version of the input.
     assert.isUndefined(serialized)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2305,7 +2305,7 @@ describe('serializer', function (): void {
     // WHEN it is serialized.
     const serialized = Serializer.regularKeyToJSON(regularKey)
 
-    // THEN the output is the serialized version of the input.
+    // THEN the output is undefined.
     assert.isUndefined(serialized)
   })
 


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for RegularKey protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `RegularKey` and adds associated unit tests. 

Docs:  https://xrpl.org/setregularkey.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 