### PR TITLE
Serialize SignerQuorum Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -43,6 +43,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  SignerQuorum,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -250,6 +251,7 @@ type OwnerJSON = string
 type ConditionJSON = string
 type CancelAfterJSON = number
 type FinishAfterJSON = number
+type SignerQuorumJSON = number
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -1255,6 +1257,16 @@ const serializer = {
     }
 
     return json
+  },
+
+  /**
+   * Convert a SignerQuorum to a JSON representation.
+   *
+   * @param signerQuorum - The SignerQuorum to convert.
+   * @returns The SignerQuorum as JSON.
+   */
+  signerQuorumToJSON(signerQuorum: SignerQuorum): SignerQuorumJSON | undefined {
+    return signerQuorum.getValue()
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -48,6 +48,7 @@ import {
   Condition,
   CancelAfter,
   FinishAfter,
+  SignerQuorum,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -2277,5 +2278,19 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)
+  })
+
+  it('Serializes a SignerQuorum', function (): void {
+    // GIVEN a SignerQuorum.
+    const signerQuorumValue = 2
+
+    const signerQuorum = new SignerQuorum()
+    signerQuorum.setValue(signerQuorumValue)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.signerQuorumToJSON(signerQuorum)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, signerQuorumValue)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for SignerQuorum protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `SignerQuorum` and adds associated unit tests. 

Docs:  https://xrpl.org/signerlistset.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 