### PR TITLE
Serialize SignerWeight Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -44,6 +44,7 @@ import {
   CancelAfter,
   FinishAfter,
   Fulfillment,
+  SignerWeight,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -252,6 +253,7 @@ type ConditionJSON = string
 type CancelAfterJSON = number
 type FinishAfterJSON = number
 type FulfillmentJSON = string
+type SignerWeightJSON = number
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -1267,6 +1269,16 @@ const serializer = {
     }
 
     return json
+  },
+
+  /**
+   * Convert a SignerWeight to a JSON representation.
+   *
+   * @param signerWeight - The SignerWeight to convert.
+   * @returns The SignerWeight as JSON.
+   */
+  signerWeightToJSON(signerWeight: SignerWeight): SignerWeightJSON | undefined {
+    return signerWeight.getValue()
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -49,6 +49,7 @@ import {
   CancelAfter,
   FinishAfter,
   Fulfillment,
+  SignerWeight,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -2293,5 +2294,19 @@ describe('serializer', function (): void {
 
     // THEN the result is as expected.
     assert.equal(serialized, Utils.toHex(fulfillmentBytes))
+  })
+
+  it('Serializes a SignerWeight', function (): void {
+    // GIVEN a SignerWeight.
+    const signerWeightValue = 3
+
+    const signerWeight = new SignerWeight()
+    signerWeight.setValue(signerWeightValue)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.signerWeightToJSON(signerWeight)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, signerWeightValue)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for SignerWeight protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `SignerWeight` and adds associated unit tests. 

Docs:  https://xrpl.org/signerlistset.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 