### PR TITLE
Serialize LimitAmount Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -44,6 +44,7 @@ import {
   CancelAfter,
   FinishAfter,
   Fulfillment,
+  LimitAmount,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -264,6 +265,7 @@ type ConditionJSON = string
 type CancelAfterJSON = number
 type FinishAfterJSON = number
 type FulfillmentJSON = string
+type LimitAmountJSON = CurrencyAmountJSON
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -1210,6 +1212,21 @@ const serializer = {
    */
   cancelAfterToJSON(cancelAfter: CancelAfter): CancelAfterJSON {
     return cancelAfter.getValue()
+  },
+
+  /**
+   * Convert a LimitAmount to a JSON representation.
+   *
+   * @param limitAmount - The LimitAmount to convert.
+   * @returns The LimitAmount as JSON.
+   */
+  limitAmountToJSON(limitAmount: LimitAmount): LimitAmountJSON | undefined {
+    const currencyAmount = limitAmount.getValue()
+    if (currencyAmount === undefined) {
+      return undefined
+    }
+
+    return this.currencyAmountToJSON(currencyAmount)
   },
 
   /**

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -49,6 +49,7 @@ import {
   CancelAfter,
   FinishAfter,
   Fulfillment,
+  LimitAmount,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -2383,6 +2384,34 @@ describe('serializer', function (): void {
 
     // WHEN it is serialized.
     const serialized = Serializer.escrowFinishToJSON(escrowFinish)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Serializes a LimitAmount', function (): void {
+    // GIVEN a LimitAmount
+    const currencyAmount = makeXrpCurrencyAmount('10')
+
+    const limitAmount = new LimitAmount()
+    limitAmount.setValue(currencyAmount)
+
+    // WHEN the LimitAmount is serialized.
+    const serialized = Serializer.limitAmountToJSON(limitAmount)
+
+    // THEN the result is the serialized version of the inputs.
+    assert.deepEqual(
+      serialized,
+      Serializer.currencyAmountToJSON(currencyAmount),
+    )
+  })
+
+  it('Fails to serialize a malformed LimitAmount', function (): void {
+    // GIVEN a malformed LimitAmount
+    const limitAmount = new LimitAmount()
+
+    // WHEN the LimitAmount is serialized.
+    const serialized = Serializer.limitAmountToJSON(limitAmount)
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for LimitAmount protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `LimitAmount` and adds associated unit tests. 

Docs: https://xrpl.org/trustset.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 