### PR TITLE
Serialize QualityIn/QualityOut Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -44,6 +44,8 @@ import {
   CancelAfter,
   FinishAfter,
   Fulfillment,
+  QualityIn,
+  QualityOut,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -264,6 +266,8 @@ type ConditionJSON = string
 type CancelAfterJSON = number
 type FinishAfterJSON = number
 type FulfillmentJSON = string
+type QualityInJSON = number
+type QualityOutJSON = number
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -1210,6 +1214,26 @@ const serializer = {
    */
   cancelAfterToJSON(cancelAfter: CancelAfter): CancelAfterJSON {
     return cancelAfter.getValue()
+  },
+
+  /**
+   * Convert a QualityIn to a JSON representation.
+   *
+   * @param qualityIn - The QualityIn to convert.
+   * @returns The QualityIn as JSON.
+   */
+  qualityInToJSON(qualityIn: QualityIn): QualityInJSON {
+    return qualityIn.getValue()
+  },
+
+  /**
+   * Convert a QualityOut to a JSON representation.
+   *
+   * @param qualityOut - The QualityOut to convert.
+   * @returns The QualityOut as JSON.
+   */
+  qualityOutToJSON(qualityOut: QualityOut): QualityOutJSON {
+    return qualityOut.getValue()
   },
 
   /**

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -49,6 +49,8 @@ import {
   CancelAfter,
   FinishAfter,
   Fulfillment,
+  QualityIn,
+  QualityOut,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -1950,6 +1952,32 @@ describe('serializer', function (): void {
 
     // THEN the result is as expected.
     assert.equal(serialized, cancelAfterTime)
+  })
+
+  it('Serializes a QualityIn', function (): void {
+    // GIVEN a QualityIn.
+    const qualityInValue = 6
+    const qualityIn = new QualityIn()
+    qualityIn.setValue(qualityInValue)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.qualityInToJSON(qualityIn)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, qualityInValue)
+  })
+
+  it('Serializes a QualityOut', function (): void {
+    // GIVEN a QualityOut.
+    const qualityOutValue = 7
+    const qualityOut = new QualityOut()
+    qualityOut.setValue(qualityOutValue)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.qualityOutToJSON(qualityOut)
+
+    // THEN the result is as expected.
+    assert.equal(serialized, qualityOutValue)
   })
 
   it('Serializes a FinishAfter', function (): void {


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for Quality{In,Out} protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `Quality{In,Out}` and adds associated unit tests. 

Docs: https://xrpl.org/trustset.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 