### PR TITLE
Serialize PaymentChannelFund Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -65,6 +65,7 @@ import {
   EscrowCancel,
   EscrowCreate,
   EscrowFinish,
+  PaymentChannelFund,
 } from './generated/org/xrpl/rpc/v1/transaction_pb'
 import XrpUtils from './xrp-utils'
 
@@ -163,6 +164,13 @@ interface CheckCancelJSON {
   CheckID: CheckIDJSON
 }
 
+export interface PaymentChannelFundJSON {
+  Channel: ChannelJSON
+  Amount: AmountJSON
+  Expiration?: ExpirationJSON
+  TransactionType: "PaymentChannelFund"
+}
+
 export interface OfferCreateJSON {
   Expiration?: ExpirationJSON
   OfferSequence?: OfferSequenceJSON
@@ -184,6 +192,7 @@ type TransactionDataJSON =
   | OfferCancelJSON
   | OfferCreateJSON
   | PaymentJSON
+  | PaymentChannelFundJSON
 
 /**
  * Individual Transaction Types.
@@ -200,6 +209,7 @@ type EscrowCancelTransactionJSON = BaseTransactionJSON & EscrowCancelJSON
 type EscrowCreateTransactionJSON = BaseTransactionJSON & EscrowCreateJSON
 type EscrowFinishTransactionJSON = BaseTransactionJSON & EscrowFinishJSON
 type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
+type PaymentChannelFundTransactionJSON = BaseTransactionJSON & PaymentChannelFundTransactionJSON
 
 /**
  * All Transactions.
@@ -217,6 +227,7 @@ export type TransactionJSON =
   | OfferCancelTransactionJSON
   | OfferCreateTransactionJSON
   | PaymentTransactionJSON
+  | PaymentChannelFundTransactionJSON
 
 /**
  * Types for serialized sub-objects.
@@ -1458,6 +1469,35 @@ const serializer = {
 
     return this.currencyAmountToJSON(currencyAmount)
   },
+
+  /**
+   * Convert a PaymentChannelFund to a JSON representation.
+   * 
+   * @param paymentChannelFund - The PaymentChannelFund to convert.
+   * @returns The PaymentChannelFund as JSON.
+   */
+  paymentChannelFundToJSON(paymentChannelFund: PaymentChannelFund): PaymentChannelFundJSON | undefined {
+    // Process mandatory fields.
+    const channel = paymentChannelFund.getChannel()
+    const amount = paymentChannelFund.getAmount()
+    if (channel === undefined || amount === undefined) {
+      return undefined
+    }
+
+    const json: PaymentChannelFundJSON = {
+      Channel: this.channelToJSON(channel),
+      Amount: this.amountToJSON(amount),
+      TransactionType: "PaymentChannelFund",
+    }
+
+    // Process optional fields. 
+    const expiration = paymentChannelFund.getExpiration()
+    if (expiration !== undefined) {
+      json.Expiration = this.expirationToJSON(expiration)
+    }
+
+    return json
+  }
 }
 
 export default serializer

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -170,7 +170,7 @@ export interface PaymentChannelFundJSON {
   Channel: ChannelJSON
   Amount: AmountJSON
   Expiration?: ExpirationJSON
-  TransactionType: "PaymentChannelFund"
+  TransactionType: 'PaymentChannelFund'
 }
 
 export interface OfferCreateJSON {
@@ -211,7 +211,8 @@ type EscrowCancelTransactionJSON = BaseTransactionJSON & EscrowCancelJSON
 type EscrowCreateTransactionJSON = BaseTransactionJSON & EscrowCreateJSON
 type EscrowFinishTransactionJSON = BaseTransactionJSON & EscrowFinishJSON
 type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
-type PaymentChannelFundTransactionJSON = BaseTransactionJSON & PaymentChannelFundTransactionJSON
+type PaymentChannelFundTransactionJSON = BaseTransactionJSON &
+  PaymentChannelFundTransactionJSON
 
 /**
  * All Transactions.
@@ -1383,7 +1384,7 @@ const serializer = {
     return Utils.toHex(channel.getValue_asU8())
   },
 
-  /** 
+  /**
    * Convert a SignerQuorum to a JSON representation.
    *
    * @param signerQuorum - The SignerQuorum to convert.
@@ -1392,7 +1393,7 @@ const serializer = {
   signerQuorumToJSON(signerQuorum: SignerQuorum): SignerQuorumJSON | undefined {
     return signerQuorum.getValue()
   },
-    
+
   /**
    * Convert an OfferCreate to a JSON representation.
    *
@@ -1431,8 +1432,8 @@ const serializer = {
 
     return json
   },
-    
-  /**    
+
+  /**
    * Convert a RegularKey to a JSON representation.
    *
    * @param regularKey - The RegularKey to convert.
@@ -1456,7 +1457,7 @@ const serializer = {
   settleDelayToJSON(settleDelay: SettleDelay): SettleDelayJSON {
     return settleDelay.getValue()
   },
-    
+
   /**
    * Convert a PaymentChannelSignature to a JSON representation.
    *
@@ -1468,7 +1469,7 @@ const serializer = {
   ): PaymentChannelSignatureJSON {
     return Utils.toHex(paymentChannelSignature.getValue_asU8())
   },
-    
+
   /**
    * Convert a PublicKey to a JSON representation.
    *
@@ -1478,7 +1479,7 @@ const serializer = {
   publicKeyToJSON(publicKey: PublicKey): PublicKeyJSON {
     return Utils.toHex(publicKey.getValue_asU8())
   },
-  
+
   /**
    * Convert a Balance to a JSON representation.
    *
@@ -1496,11 +1497,13 @@ const serializer = {
 
   /**
    * Convert a PaymentChannelFund to a JSON representation.
-   * 
+   *
    * @param paymentChannelFund - The PaymentChannelFund to convert.
    * @returns The PaymentChannelFund as JSON.
    */
-  paymentChannelFundToJSON(paymentChannelFund: PaymentChannelFund): PaymentChannelFundJSON | undefined {
+  paymentChannelFundToJSON(
+    paymentChannelFund: PaymentChannelFund,
+  ): PaymentChannelFundJSON | undefined {
     // Process mandatory fields.
     const channel = paymentChannelFund.getChannel()
     const amount = paymentChannelFund.getAmount()
@@ -1508,20 +1511,25 @@ const serializer = {
       return undefined
     }
 
-    const json: PaymentChannelFundJSON = {
-      Channel: this.channelToJSON(channel),
-      Amount: this.amountToJSON(amount),
-      TransactionType: "PaymentChannelFund",
+    const amountJSON = this.amountToJSON(amount)
+    if (amountJSON === undefined) {
+      return undefined
     }
 
-    // Process optional fields. 
+    const json: PaymentChannelFundJSON = {
+      Channel: this.channelToJSON(channel),
+      Amount: amountJSON,
+      TransactionType: 'PaymentChannelFund',
+    }
+
+    // Process optional fields.
     const expiration = paymentChannelFund.getExpiration()
     if (expiration !== undefined) {
       json.Expiration = this.expirationToJSON(expiration)
     }
 
     return json
-  }
+  },
 }
 
 export default serializer

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -216,7 +216,7 @@ type EscrowCreateTransactionJSON = BaseTransactionJSON & EscrowCreateJSON
 type EscrowFinishTransactionJSON = BaseTransactionJSON & EscrowFinishJSON
 type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
 type PaymentChannelFundTransactionJSON = BaseTransactionJSON &
-  PaymentChannelFundTransactionJSON
+  PaymentChannelFundJSON
 
 /**
  * All Transactions.
@@ -1427,7 +1427,7 @@ const serializer = {
     return signerWeight.getValue()
   },
 
-  /** 
+  /**
    * Convert a Channel to a JSON representation.
    *
    * @param channel - The Channel to convert.

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2216,7 +2216,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(channelValue))
   })
-  
+
   it('Serializes an OfferCreate with only mandatory fields', function (): void {
     // GIVEN a OfferCreate with mandatory fields set.
     const takerPays = new TakerPays()
@@ -2298,7 +2298,7 @@ describe('serializer', function (): void {
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Serializes a PublicKey', function (): void {
     // GIVEN a PublicKey.
     const publicKeyValue = new Uint8Array([1, 2, 3, 4])
@@ -2312,7 +2312,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(publicKeyValue))
   })
-    
+
   it('Serializes a Balance', function (): void {
     // GIVEN a Balance.
     const currencyAmount = makeXrpCurrencyAmount('10')
@@ -2337,7 +2337,7 @@ describe('serializer', function (): void {
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Converts a PathList', function (): void {
     // GIVEN a Path list with two paths.
     const path1Element1 = makePathElement(
@@ -2561,7 +2561,7 @@ describe('serializer', function (): void {
     // THEN the result is as expected.
     assert.equal(serialized, settleDelayValue)
   })
-    
+
   it('Serializes a PaymentChannelSignature', function (): void {
     // GIVEN a PaymentChannelSignature.
     const paymentChannelSignatureValue = new Uint8Array([1, 2, 3, 4])
@@ -2577,7 +2577,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(paymentChannelSignatureValue))
   })
-    
+
   it('Serializes a Fulfillment', function (): void {
     // GIVEN a Fulfillment with some bytes.
     const fulfillmentBytes = new Uint8Array([0, 1, 2, 3])
@@ -2696,7 +2696,7 @@ describe('serializer', function (): void {
   it('Serializes a PaymentChannelFund with mandatory fields set.', function (): void {
     // GIVEN a PaymentChannelFund with mandatory fields set.
     const amount = new Amount()
-    amount.setValue(makeXrpCurrencyAmount("10"))
+    amount.setValue(makeXrpCurrencyAmount('10'))
 
     const channel = new Channel()
     channel.setValue(new Uint8Array([1, 2, 3, 4]))
@@ -2712,8 +2712,66 @@ describe('serializer', function (): void {
     const expected: PaymentChannelFundJSON = {
       Amount: Serializer.amountToJSON(amount),
       Channel: Serializer.channelToJSON(channel),
-      TransactionType: "PaymentChannelFund"
+      TransactionType: 'PaymentChannelFund',
     }
     assert.deepEqual(serialized, expected)
+  })
+
+  it('Serializes a PaymentChannelFund with all fields set.', function (): void {
+    // GIVEN a PaymentChannelFund with all fields set.
+    const amount = new Amount()
+    amount.setValue(makeXrpCurrencyAmount('10'))
+
+    const channel = new Channel()
+    channel.setValue(new Uint8Array([1, 2, 3, 4]))
+
+    const expiration = new Expiration()
+    expiration.setValue(5)
+
+    const paymentChannelFund = new PaymentChannelFund()
+    paymentChannelFund.setAmount(amount)
+    paymentChannelFund.setChannel(channel)
+    paymentChannelFund.setExpiration(expiration)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentChannelFundToJSON(paymentChannelFund)
+
+    // THEN the result is in the expected form.
+    const expected: PaymentChannelFundJSON = {
+      Amount: Serializer.amountToJSON(amount),
+      Channel: Serializer.channelToJSON(channel),
+      Expiration: Serializer.expirationToJSON(expiration),
+      TransactionType: 'PaymentChannelFund',
+    }
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Fails to serialize a PaymentChannelFund with a malformed amount field.', function (): void {
+    // GIVEN a PaymentChannelFund with a malformed amount field
+    const amount = new Amount()
+
+    const channel = new Channel()
+    channel.setValue(new Uint8Array([1, 2, 3, 4]))
+
+    const paymentChannelFund = new PaymentChannelFund()
+    paymentChannelFund.setAmount(amount)
+    paymentChannelFund.setChannel(channel)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentChannelFundToJSON(paymentChannelFund)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Fails to serialize a malformed PaymentChannelFund', function (): void {
+    // GIVEN a malformed PaymentChannelFund/
+    const paymentChannelFund = new PaymentChannelFund()
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentChannelFundToJSON(paymentChannelFund)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
   })
 })

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -56,7 +56,6 @@ import {
   PublicKey,
   Balance,
   Fulfillment,
-  Channel,
   SignerWeight,
   QualityIn,
   QualityOut,
@@ -2634,7 +2633,7 @@ describe('serializer', function (): void {
     // THEN the result is as expected.
     assert.equal(serialized, signerWeightValue)
   })
-    
+
   it('Serializes an EscrowFinish with required fields', function (): void {
     // GIVEN an EscrowFinish with required fields.
     const offerSequence = new OfferSequence()
@@ -2754,7 +2753,7 @@ describe('serializer', function (): void {
 
     // THEN the result is in the expected form.
     const expected: PaymentChannelFundJSON = {
-      Amount: Serializer.amountToJSON(amount),
+      Amount: Serializer.amountToJSON(amount)!,
       Channel: Serializer.channelToJSON(channel),
       TransactionType: 'PaymentChannelFund',
     }
@@ -2782,7 +2781,7 @@ describe('serializer', function (): void {
 
     // THEN the result is in the expected form.
     const expected: PaymentChannelFundJSON = {
-      Amount: Serializer.amountToJSON(amount),
+      Amount: Serializer.amountToJSON(amount)!,
       Channel: Serializer.channelToJSON(channel),
       Expiration: Serializer.expirationToJSON(expiration),
       TransactionType: 'PaymentChannelFund',
@@ -2818,7 +2817,7 @@ describe('serializer', function (): void {
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Serializes a LimitAmount', function (): void {
     // GIVEN a LimitAmount
     const currencyAmount = makeXrpCurrencyAmount('10')

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -54,6 +54,7 @@ import {
   PublicKey,
   Balance,
   Fulfillment,
+  Channel,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -70,6 +71,7 @@ import {
   EscrowCreate,
   EscrowFinish,
   OfferCancel,
+  PaymentChannelFund,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer, {
   CheckCreateJSON,
@@ -81,6 +83,7 @@ import Serializer, {
   TransactionJSON,
   OfferCreateJSON,
   PaymentJSON,
+  PaymentChannelFundJSON,
 } from '../../src/XRP/serializer'
 import XrpUtils from '../../src/XRP/xrp-utils'
 
@@ -2658,5 +2661,29 @@ describe('serializer', function (): void {
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)
+  })
+
+  it('Serializes a PaymentChannelFund with mandatory fields set.', function (): void {
+    // GIVEN a PaymentChannelFund with mandatory fields set.
+    const amount = new Amount()
+    amount.setValue(makeXrpCurrencyAmount("10"))
+
+    const channel = new Channel()
+    channel.setValue(new Uint8Array([1, 2, 3, 4]))
+
+    const paymentChannelFund = new PaymentChannelFund()
+    paymentChannelFund.setAmount(amount)
+    paymentChannelFund.setChannel(channel)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentChannelFundToJSON(paymentChannelFund)
+
+    // THEN the result is in the expected form.
+    const expected: PaymentChannelFundJSON = {
+      Amount: Serializer.amountToJSON(amount),
+      Channel: Serializer.channelToJSON(channel),
+      TransactionType: "PaymentChannelFund"
+    }
+    assert.deepEqual(serialized, expected)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for PaymentChannelFund protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `PaymentChannelFund` and adds associated unit tests. 

Docs:  https://xrpl.org/paymentchannelfund.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 