### PR TITLE
Serialize PaymentChannelCreate Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -219,7 +219,7 @@ type EscrowCreateTransactionJSON = BaseTransactionJSON & EscrowCreateJSON
 type EscrowFinishTransactionJSON = BaseTransactionJSON & EscrowFinishJSON
 type PaymentTransactionJSON = BaseTransactionJSON & PaymentJSON
 type PaymentChannelCreateTransactionJSON = BaseTransactionJSON &
-  PaymentChannelSignatureJSON
+  PaymentChannelCreateJSON
 
 /**
  * All Transactions.

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -1,7 +1,6 @@
 /* eslint-disable  max-lines --
  * gRPC is verbose. Playing code golf with this file would decrease clarity for little readability gain.
  */
-import { Serializer } from '..'
 import Utils from '../Common/utils'
 
 import { AccountAddress } from './generated/org/xrpl/rpc/v1/account_pb'
@@ -1431,7 +1430,7 @@ const serializer = {
     return signerWeight.getValue()
   },
 
-  /** 
+  /**
    * Convert a Channel to a JSON representation.
    *
    * @param channel - The Channel to convert.
@@ -1584,8 +1583,8 @@ const serializer = {
     const json: PaymentChannelCreateJSON = {
       Amount: amountJSON,
       Destination: destinationJSON,
-      SettleDelay: Serializer.settleDelayToJSON(settleDelay),
-      PublicKey: Serializer.publicKeyToJSON(publicKey),
+      SettleDelay: this.settleDelayToJSON(settleDelay),
+      PublicKey: this.publicKeyToJSON(publicKey),
       TransactionType: 'PaymentChannelCreate',
     }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2213,7 +2213,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(channelValue))
   })
-  
+
   it('Serializes an OfferCreate with only mandatory fields', function (): void {
     // GIVEN a OfferCreate with mandatory fields set.
     const takerPays = new TakerPays()
@@ -2295,7 +2295,7 @@ describe('serializer', function (): void {
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Serializes a PublicKey', function (): void {
     // GIVEN a PublicKey.
     const publicKeyValue = new Uint8Array([1, 2, 3, 4])
@@ -2309,7 +2309,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(publicKeyValue))
   })
-    
+
   it('Serializes a Balance', function (): void {
     // GIVEN a Balance.
     const currencyAmount = makeXrpCurrencyAmount('10')
@@ -2334,7 +2334,7 @@ describe('serializer', function (): void {
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Converts a PathList', function (): void {
     // GIVEN a Path list with two paths.
     const path1Element1 = makePathElement(
@@ -2558,7 +2558,7 @@ describe('serializer', function (): void {
     // THEN the result is as expected.
     assert.equal(serialized, settleDelayValue)
   })
-    
+
   it('Serializes a PaymentChannelSignature', function (): void {
     // GIVEN a PaymentChannelSignature.
     const paymentChannelSignatureValue = new Uint8Array([1, 2, 3, 4])
@@ -2574,7 +2574,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(paymentChannelSignatureValue))
   })
-    
+
   it('Serializes a Fulfillment', function (): void {
     // GIVEN a Fulfillment with some bytes.
     const fulfillmentBytes = new Uint8Array([0, 1, 2, 3])

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -76,6 +76,7 @@ import {
   EscrowCreate,
   EscrowFinish,
   OfferCancel,
+  PaymentChannelCreate,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer, {
   CheckCreateJSON,
@@ -87,6 +88,7 @@ import Serializer, {
   TransactionJSON,
   OfferCreateJSON,
   PaymentJSON,
+  PaymentChannelCreateJSON,
 } from '../../src/XRP/serializer'
 import XrpUtils from '../../src/XRP/xrp-utils'
 
@@ -2631,7 +2633,7 @@ describe('serializer', function (): void {
     // THEN the result is as expected.
     assert.equal(serialized, signerWeightValue)
   })
-    
+
   it('Serializes an EscrowFinish with required fields', function (): void {
     // GIVEN an EscrowFinish with required fields.
     const offerSequence = new OfferSequence()
@@ -2759,6 +2761,129 @@ describe('serializer', function (): void {
     const serialized = Serializer.limitAmountToJSON(limitAmount)
 
     // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Serializes a PaymentChannelCreate with mandatory fields', function (): void {
+    // GIVEN a PaymentChannelCreate with only mandatory fields set.
+    const amount = new Amount()
+    amount.setValue(makeXrpCurrencyAmount('11'))
+
+    const destination = new Destination()
+    destination.setValue(testAccountAddress)
+
+    const settleDelay = new SettleDelay()
+    settleDelay.setValue(12)
+
+    const publicKey = new PublicKey()
+    publicKey.setValue(new Uint8Array([1, 2, 3, 4]))
+
+    const paymentChannelCreate = new PaymentChannelCreate()
+    paymentChannelCreate.setAmount(amount)
+    paymentChannelCreate.setDestination(destination)
+    paymentChannelCreate.setSettleDelay(settleDelay)
+    paymentChannelCreate.setPublicKey(publicKey)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentChannelCreateToJSON(
+      paymentChannelCreate,
+    )
+
+    // THEN the result is in the expected form.
+    const expected: PaymentChannelCreateJSON = {
+      Amount: Serializer.amountToJSON(amount)!,
+      Destination: Serializer.destinationToJSON(destination)!,
+      SettleDelay: Serializer.settleDelayToJSON(settleDelay),
+      PublicKey: Serializer.publicKeyToJSON(publicKey),
+      TransactionType: 'PaymentChannelCreate',
+    }
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Serializes a PaymentChannelCreate with all fields', function (): void {
+    // GIVEN a PaymentChannelCreate with all fields set.
+    const amount = new Amount()
+    amount.setValue(makeXrpCurrencyAmount('11'))
+
+    const destination = new Destination()
+    destination.setValue(testAccountAddress)
+
+    const settleDelay = new SettleDelay()
+    settleDelay.setValue(12)
+
+    const publicKey = new PublicKey()
+    publicKey.setValue(new Uint8Array([1, 2, 3, 4]))
+
+    const cancelAfter = new CancelAfter()
+    cancelAfter.setValue(13)
+
+    const destinationTag = new DestinationTag()
+    destinationTag.setValue(14)
+
+    const paymentChannelCreate = new PaymentChannelCreate()
+    paymentChannelCreate.setAmount(amount)
+    paymentChannelCreate.setDestination(destination)
+    paymentChannelCreate.setSettleDelay(settleDelay)
+    paymentChannelCreate.setPublicKey(publicKey)
+    paymentChannelCreate.setCancelAfter(cancelAfter)
+    paymentChannelCreate.setDestinationTag(destinationTag)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentChannelCreateToJSON(
+      paymentChannelCreate,
+    )
+
+    // THEN the result is in the expected form.
+    const expected: PaymentChannelCreateJSON = {
+      Amount: Serializer.amountToJSON(amount)!,
+      Destination: Serializer.destinationToJSON(destination)!,
+      SettleDelay: Serializer.settleDelayToJSON(settleDelay),
+      PublicKey: Serializer.publicKeyToJSON(publicKey),
+      CancelAfter: Serializer.cancelAfterToJSON(cancelAfter),
+      DestinationTag: Serializer.destinationTagToJSON(destinationTag),
+      TransactionType: 'PaymentChannelCreate',
+    }
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Fails to serialize a PaymentChannelCreate with a malformed amount', function (): void {
+    // GIVEN a PaymentChannelCreate with a malformed amount field.
+    const amount = new Amount()
+
+    const destination = new Destination()
+    destination.setValue(testAccountAddress)
+
+    const settleDelay = new SettleDelay()
+    settleDelay.setValue(12)
+
+    const publicKey = new PublicKey()
+    publicKey.setValue(new Uint8Array([1, 2, 3, 4]))
+
+    const paymentChannelCreate = new PaymentChannelCreate()
+    paymentChannelCreate.setAmount(amount)
+    paymentChannelCreate.setDestination(destination)
+    paymentChannelCreate.setSettleDelay(settleDelay)
+    paymentChannelCreate.setPublicKey(publicKey)
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentChannelCreateToJSON(
+      paymentChannelCreate,
+    )
+
+    // THEN the result is undefined
+    assert.isUndefined(serialized)
+  })
+
+  it('Fails to serialize a malformed PaymentChannelCreate', function (): void {
+    // GIVEN a malformed PaymentChannelCreate.
+    const paymentChannelCreate = new PaymentChannelCreate()
+
+    // WHEN it is serialized.
+    const serialized = Serializer.paymentChannelCreateToJSON(
+      paymentChannelCreate,
+    )
+
+    // THEN the result is undefined
     assert.isUndefined(serialized)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for PaymentChannelCreate protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `PaymentChannelCreate ` and adds associated unit tests. 

Docs:  https://xrpl.org/paymentchannelcreate.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 