### PR TITLE
Serializes TrustSet Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -71,6 +71,7 @@ import {
   EscrowCancel,
   EscrowCreate,
   EscrowFinish,
+  TrustSet,
 } from './generated/org/xrpl/rpc/v1/transaction_pb'
 import XrpUtils from './xrp-utils'
 
@@ -174,6 +175,13 @@ export interface OfferCreateJSON {
   OfferSequence?: OfferSequenceJSON
   TakerGets: TakerGetsJSON
   TakerPays: TakerPaysJSON
+}
+
+export interface TrustSetJSON {
+  LimitAmount: LimitAmountJSON,
+  QualityIn?: QualityInJSON,
+  QualityOut?: QualityOutJSON,
+  TransactionType: 'TrustSet'
 }
 
 // Generic field representing an OR of all above fields.
@@ -1535,6 +1543,41 @@ const serializer = {
 
     return this.currencyAmountToJSON(currencyAmount)
   },
+
+  /**
+   * Convert a TrustSet to a JSON representation.
+   * 
+   * @param trustSet - The TrustSet to convert.
+   * @returns The TrustSet as JSON.
+   */
+  trustSetToJSON(trustSet: TrustSet): TrustSetJSON | undefined {
+    const limitAmount = trustSet.getLimitAmount()
+    if (limitAmount === undefined) {
+      return undefined
+    }
+
+    const limitAmountJson = this.limitAmountToJSON(limitAmount)
+    if (limitAmountJson === undefined) {
+      return undefined
+    }
+
+    const json: TrustSetJSON = {
+      LimitAmount: limitAmountJson,
+      TransactionType: 'TrustSet',
+    }
+
+    const qualityIn = trustSet.getQualityIn()
+    if (qualityIn !== undefined) {
+      json.QualityIn = this.qualityInToJSON(qualityIn)
+    }
+
+    const qualityOut = trustSet.getQualityOut()
+    if (qualityOut !== undefined) {
+      json.QualityOut = this.qualityOutToJSON(qualityOut)
+    }
+
+    return json
+  }
 }
 
 export default serializer

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -178,9 +178,9 @@ export interface OfferCreateJSON {
 }
 
 export interface TrustSetJSON {
-  LimitAmount: LimitAmountJSON,
-  QualityIn?: QualityInJSON,
-  QualityOut?: QualityOutJSON,
+  LimitAmount: LimitAmountJSON
+  QualityIn?: QualityInJSON
+  QualityOut?: QualityOutJSON
   TransactionType: 'TrustSet'
 }
 
@@ -1423,7 +1423,7 @@ const serializer = {
     return signerWeight.getValue()
   },
 
-  /** 
+  /**
    * Convert a Channel to a JSON representation.
    *
    * @param channel - The Channel to convert.
@@ -1433,7 +1433,7 @@ const serializer = {
     return Utils.toHex(channel.getValue_asU8())
   },
 
-  /** 
+  /**
    * Convert a SignerQuorum to a JSON representation.
    *
    * @param signerQuorum - The SignerQuorum to convert.
@@ -1442,7 +1442,7 @@ const serializer = {
   signerQuorumToJSON(signerQuorum: SignerQuorum): SignerQuorumJSON | undefined {
     return signerQuorum.getValue()
   },
-    
+
   /**
    * Convert an OfferCreate to a JSON representation.
    *
@@ -1481,8 +1481,8 @@ const serializer = {
 
     return json
   },
-    
-  /**    
+
+  /**
    * Convert a RegularKey to a JSON representation.
    *
    * @param regularKey - The RegularKey to convert.
@@ -1506,7 +1506,7 @@ const serializer = {
   settleDelayToJSON(settleDelay: SettleDelay): SettleDelayJSON {
     return settleDelay.getValue()
   },
-    
+
   /**
    * Convert a PaymentChannelSignature to a JSON representation.
    *
@@ -1518,7 +1518,7 @@ const serializer = {
   ): PaymentChannelSignatureJSON {
     return Utils.toHex(paymentChannelSignature.getValue_asU8())
   },
-    
+
   /**
    * Convert a PublicKey to a JSON representation.
    *
@@ -1528,7 +1528,7 @@ const serializer = {
   publicKeyToJSON(publicKey: PublicKey): PublicKeyJSON {
     return Utils.toHex(publicKey.getValue_asU8())
   },
-  
+
   /**
    * Convert a Balance to a JSON representation.
    *
@@ -1546,7 +1546,7 @@ const serializer = {
 
   /**
    * Convert a TrustSet to a JSON representation.
-   * 
+   *
    * @param trustSet - The TrustSet to convert.
    * @returns The TrustSet as JSON.
    */
@@ -1577,7 +1577,7 @@ const serializer = {
     }
 
     return json
-  }
+  },
 }
 
 export default serializer

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -76,6 +76,7 @@ import {
   EscrowCreate,
   EscrowFinish,
   OfferCancel,
+  TrustSet,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer, {
   CheckCreateJSON,
@@ -87,6 +88,7 @@ import Serializer, {
   TransactionJSON,
   OfferCreateJSON,
   PaymentJSON,
+  TrustSetJSON,
 } from '../../src/XRP/serializer'
 import XrpUtils from '../../src/XRP/xrp-utils'
 
@@ -2243,7 +2245,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(channelValue))
   })
-  
+
   it('Serializes an OfferCreate with only mandatory fields', function (): void {
     // GIVEN a OfferCreate with mandatory fields set.
     const takerPays = new TakerPays()
@@ -2325,7 +2327,7 @@ describe('serializer', function (): void {
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Serializes a PublicKey', function (): void {
     // GIVEN a PublicKey.
     const publicKeyValue = new Uint8Array([1, 2, 3, 4])
@@ -2339,7 +2341,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(publicKeyValue))
   })
-    
+
   it('Serializes a Balance', function (): void {
     // GIVEN a Balance.
     const currencyAmount = makeXrpCurrencyAmount('10')
@@ -2364,7 +2366,7 @@ describe('serializer', function (): void {
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Converts a PathList', function (): void {
     // GIVEN a Path list with two paths.
     const path1Element1 = makePathElement(
@@ -2588,7 +2590,7 @@ describe('serializer', function (): void {
     // THEN the result is as expected.
     assert.equal(serialized, settleDelayValue)
   })
-    
+
   it('Serializes a PaymentChannelSignature', function (): void {
     // GIVEN a PaymentChannelSignature.
     const paymentChannelSignatureValue = new Uint8Array([1, 2, 3, 4])
@@ -2604,7 +2606,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(paymentChannelSignatureValue))
   })
-    
+
   it('Serializes a Fulfillment', function (): void {
     // GIVEN a Fulfillment with some bytes.
     const fulfillmentBytes = new Uint8Array([0, 1, 2, 3])
@@ -2631,7 +2633,7 @@ describe('serializer', function (): void {
     // THEN the result is as expected.
     assert.equal(serialized, signerWeightValue)
   })
-    
+
   it('Serializes an EscrowFinish with required fields', function (): void {
     // GIVEN an EscrowFinish with required fields.
     const offerSequence = new OfferSequence()
@@ -2757,6 +2759,87 @@ describe('serializer', function (): void {
 
     // WHEN the LimitAmount is serialized.
     const serialized = Serializer.limitAmountToJSON(limitAmount)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Serializes a TrustSet with required fields', function (): void {
+    // GIVEN a TrustSet with required fields.
+    const currencyAmount = makeXrpCurrencyAmount('10')
+
+    const limitAmount = new LimitAmount()
+    limitAmount.setValue(currencyAmount)
+
+    const trustSet = new TrustSet()
+    trustSet.setLimitAmount(limitAmount)
+
+    // WHEN the TrustSet is serialized.
+    const serialized = Serializer.trustSetToJSON(trustSet)
+
+    // THEN the result is as expected.
+    const expected: TrustSetJSON = {
+      LimitAmount: Serializer.limitAmountToJSON(limitAmount)!,
+      TransactionType: 'TrustSet',
+    }
+
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Serializes a TrustSet with all fields', function (): void {
+    // GIVEN a TrustSet with all fields.
+    const currencyAmount = makeXrpCurrencyAmount('10')
+
+    const limitAmount = new LimitAmount()
+    limitAmount.setValue(currencyAmount)
+
+    const qualityInValue = 6
+    const qualityIn = new QualityIn()
+    qualityIn.setValue(qualityInValue)
+
+    const qualityOutValue = 7
+    const qualityOut = new QualityOut()
+    qualityOut.setValue(qualityOutValue)
+
+    const trustSet = new TrustSet()
+    trustSet.setLimitAmount(limitAmount)
+    trustSet.setQualityIn(qualityIn)
+    trustSet.setQualityOut(qualityOut)
+
+    // WHEN the TrustSet is serialized.
+    const serialized = Serializer.trustSetToJSON(trustSet)
+
+    // THEN the result is as expected.
+    const expected: TrustSetJSON = {
+      LimitAmount: Serializer.limitAmountToJSON(limitAmount)!,
+      QualityIn: Serializer.qualityInToJSON(qualityIn),
+      QualityOut: Serializer.qualityOutToJSON(qualityOut),
+      TransactionType: 'TrustSet',
+    }
+
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Fails to serialize a TrustSet missing limitAmount', function (): void {
+    // GIVEN a TrustSet missing a limitAmount.
+    const trustSet = new TrustSet()
+
+    // WHEN the TrustSet is serialized.
+    const serialized = Serializer.trustSetToJSON(trustSet)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Fails to serialize a TrustSet with malformed limitAmount', function (): void {
+    // GIVEN a TrustSet with a malformed limitAmount.
+    const limitAmount = new LimitAmount()
+
+    const trustSet = new TrustSet()
+    trustSet.setLimitAmount(limitAmount)
+
+    // WHEN the TrustSet is serialized.
+    const serialized = Serializer.trustSetToJSON(trustSet)
 
     // THEN the result is undefined.
     assert.isUndefined(serialized)


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for TrustSet protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `TrustSet` and adds associated unit tests. 

Docs:  https://xrpl.org/trustset.html

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 