### PR TITLE
Serialize SignerEntry Protocol Buffers

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -55,6 +55,7 @@ import {
   QualityIn,
   QualityOut,
   LimitAmount,
+  SignerEntry,
 } from './generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -227,6 +228,11 @@ export type TransactionJSON =
 /**
  * Types for serialized sub-objects.
  */
+interface SignerEntryJSON {
+  Account: AccountJSON
+  SignerWeight: SignerWeightJSON
+}
+
 interface MemoJSON {
   Memo?: MemoDetailsJSON
 }
@@ -1415,7 +1421,7 @@ const serializer = {
     return signerWeight.getValue()
   },
 
-  /** 
+  /**
    * Convert a Channel to a JSON representation.
    *
    * @param channel - The Channel to convert.
@@ -1425,7 +1431,7 @@ const serializer = {
     return Utils.toHex(channel.getValue_asU8())
   },
 
-  /** 
+  /**
    * Convert a SignerQuorum to a JSON representation.
    *
    * @param signerQuorum - The SignerQuorum to convert.
@@ -1434,7 +1440,7 @@ const serializer = {
   signerQuorumToJSON(signerQuorum: SignerQuorum): SignerQuorumJSON | undefined {
     return signerQuorum.getValue()
   },
-    
+
   /**
    * Convert an OfferCreate to a JSON representation.
    *
@@ -1473,8 +1479,8 @@ const serializer = {
 
     return json
   },
-    
-  /**    
+
+  /**
    * Convert a RegularKey to a JSON representation.
    *
    * @param regularKey - The RegularKey to convert.
@@ -1498,7 +1504,7 @@ const serializer = {
   settleDelayToJSON(settleDelay: SettleDelay): SettleDelayJSON {
     return settleDelay.getValue()
   },
-    
+
   /**
    * Convert a PaymentChannelSignature to a JSON representation.
    *
@@ -1510,7 +1516,7 @@ const serializer = {
   ): PaymentChannelSignatureJSON {
     return Utils.toHex(paymentChannelSignature.getValue_asU8())
   },
-    
+
   /**
    * Convert a PublicKey to a JSON representation.
    *
@@ -1520,7 +1526,7 @@ const serializer = {
   publicKeyToJSON(publicKey: PublicKey): PublicKeyJSON {
     return Utils.toHex(publicKey.getValue_asU8())
   },
-  
+
   /**
    * Convert a Balance to a JSON representation.
    *
@@ -1534,6 +1540,31 @@ const serializer = {
     }
 
     return this.currencyAmountToJSON(currencyAmount)
+  },
+
+  /**
+   * Convert a SignerEntry to a JSON representation.
+   *
+   * @param signerEntry - The SignerEntry to convert.
+   * @returns The SignerEntry as JSON.
+   */
+  signerEntryToJSON(signerEntry: SignerEntry): SignerEntryJSON | undefined {
+    const account = signerEntry.getAccount()
+    const signerWeight = signerEntry.getSignerWeight()
+    if (account === undefined || signerWeight === undefined) {
+      return undefined
+    }
+
+    const accountJSON = this.accountToJSON(account)
+    const signerWeightJSON = this.signerWeightToJSON(signerWeight)
+    if (accountJSON === undefined || signerWeightJSON === undefined) {
+      return undefined
+    }
+
+    return {
+      Account: accountJSON,
+      SignerWeight: signerWeightJSON,
+    }
   },
 }
 

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -60,6 +60,7 @@ import {
   QualityIn,
   QualityOut,
   LimitAmount,
+  SignerEntry,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -2243,7 +2244,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(channelValue))
   })
-  
+
   it('Serializes an OfferCreate with only mandatory fields', function (): void {
     // GIVEN a OfferCreate with mandatory fields set.
     const takerPays = new TakerPays()
@@ -2325,7 +2326,7 @@ describe('serializer', function (): void {
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Serializes a PublicKey', function (): void {
     // GIVEN a PublicKey.
     const publicKeyValue = new Uint8Array([1, 2, 3, 4])
@@ -2339,7 +2340,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(publicKeyValue))
   })
-    
+
   it('Serializes a Balance', function (): void {
     // GIVEN a Balance.
     const currencyAmount = makeXrpCurrencyAmount('10')
@@ -2364,7 +2365,7 @@ describe('serializer', function (): void {
     // THEN the result is undefined.
     assert.isUndefined(serialized)
   })
-    
+
   it('Converts a PathList', function (): void {
     // GIVEN a Path list with two paths.
     const path1Element1 = makePathElement(
@@ -2588,7 +2589,7 @@ describe('serializer', function (): void {
     // THEN the result is as expected.
     assert.equal(serialized, settleDelayValue)
   })
-    
+
   it('Serializes a PaymentChannelSignature', function (): void {
     // GIVEN a PaymentChannelSignature.
     const paymentChannelSignatureValue = new Uint8Array([1, 2, 3, 4])
@@ -2604,7 +2605,7 @@ describe('serializer', function (): void {
     // THEN the output is the input encoded as hex.
     assert.equal(serialized, Utils.toHex(paymentChannelSignatureValue))
   })
-    
+
   it('Serializes a Fulfillment', function (): void {
     // GIVEN a Fulfillment with some bytes.
     const fulfillmentBytes = new Uint8Array([0, 1, 2, 3])
@@ -2631,7 +2632,7 @@ describe('serializer', function (): void {
     // THEN the result is as expected.
     assert.equal(serialized, signerWeightValue)
   })
-    
+
   it('Serializes an EscrowFinish with required fields', function (): void {
     // GIVEN an EscrowFinish with required fields.
     const offerSequence = new OfferSequence()
@@ -2759,6 +2760,58 @@ describe('serializer', function (): void {
     const serialized = Serializer.limitAmountToJSON(limitAmount)
 
     // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
+  it('Serializes a SignerEntry', function (): void {
+    // GIVEN a SignerEntry
+    const account = new Account()
+    account.setValue(testAccountAddress)
+
+    const signerWeight = new SignerWeight()
+    signerWeight.setValue(1)
+
+    const signerEntry = new SignerEntry()
+    signerEntry.setAccount(account)
+    signerEntry.setSignerWeight(signerWeight)
+
+    // WHEN the SignerEntry is serialized.
+    const serialized = Serializer.signerEntryToJSON(signerEntry)
+
+    // THEN the result is the expected form.
+    const expected = {
+      Account: Serializer.accountToJSON(account)!,
+      SignerWeight: Serializer.signerWeightToJSON(signerWeight)!,
+    }
+    assert.deepEqual(serialized, expected)
+  })
+
+  it('Fails to serialize a SignerEntry with malformed components', function (): void {
+    // GIVEN a SignerEntry with a malformed account
+    const account = new Account()
+
+    const signerWeight = new SignerWeight()
+    signerWeight.setValue(1)
+
+    const signerEntry = new SignerEntry()
+    signerEntry.setAccount(account)
+    signerEntry.setSignerWeight(signerWeight)
+
+    // WHEN the SignerEntry is serialized.
+    const serialized = Serializer.signerEntryToJSON(signerEntry)
+
+    // THEN the result is undefined
+    assert.isUndefined(serialized)
+  })
+
+  it('Fails to serialize a malformed SignerEntry', function (): void {
+    // GIVEN a malformed SignerEntry
+    const signerEntry = new SignerEntry()
+
+    // WHEN the SignerEntry is serialized.
+    const serialized = Serializer.signerEntryToJSON(signerEntry)
+
+    // THEN the result is undefined
     assert.isUndefined(serialized)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization for SignerEntry protocol buffers. 

### Context of Change

Each protocol buffer (`Foo`) maps to an equivalent `FooJSON` in `Serializer`. This PR wires this conversion for `SignerEntry` and adds associated unit tests. 

Docs:  https://xrpl.org/signerlist.html#signer-entry-object

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

N/A

## Test Plan

CI - new tests provided. 