### PR TITLE
Refactors Test Utilities, Adds Signing Test for All Payment Fields

### DIFF
--- a/test/XRP/helpers/xrp-test-utils.ts
+++ b/test/XRP/helpers/xrp-test-utils.ts
@@ -29,13 +29,7 @@ import {
   AccountSet,
 } from '../../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 
-
 const xrpTestUtils = {
-
-  /* eslint-disable no-shadow, max-params --
-  * The values we are shadowing are only used as inputs for this function,
-  * and it's fine to have a ton of parameters because this function is only used for testing purposes.
-  */
   /**
    * Create a new `Transaction` object with the given inputs.
    *
@@ -315,7 +309,6 @@ const xrpTestUtils = {
 
     return transaction
   },
-  /* eslint-enable no-shadow, max-params */
 
   /**
    * Make a PathElement.
@@ -331,7 +324,7 @@ const xrpTestUtils = {
     account: AccountAddress | undefined,
     currencyCode: Uint8Array | undefined,
     issuer: AccountAddress | undefined,
-  ) {
+  ): Payment.PathElement {
     const pathElement = new Payment.PathElement()
 
     if (account !== undefined) {
@@ -357,7 +350,7 @@ const xrpTestUtils = {
    * @param drops - A numeric string representing the number of drops.
    * @returns A new XRPDropsAmount.
    */
-  makeXrpDropsAmount(drops: string) {
+  makeXrpDropsAmount(drops: string): XRPDropsAmount {
     const xrpDropsAmount = new XRPDropsAmount()
     xrpDropsAmount.setDrops(drops)
 
@@ -376,7 +369,7 @@ const xrpTestUtils = {
     accountAddress: AccountAddress,
     issuedCurrencyValue: string,
     currency: Currency,
-  ) {
+  ): IssuedCurrencyAmount {
     const issuedCurrency = new IssuedCurrencyAmount()
     issuedCurrency.setIssuer(accountAddress)
     issuedCurrency.setValue(issuedCurrencyValue)

--- a/test/XRP/helpers/xrp-test-utils.ts
+++ b/test/XRP/helpers/xrp-test-utils.ts
@@ -1,0 +1,417 @@
+import Utils from '../../../src/Common/utils'
+import { AccountAddress } from '../../../src/XRP/generated/org/xrpl/rpc/v1/account_pb'
+import {
+  CurrencyAmount,
+  XRPDropsAmount,
+  Currency,
+  IssuedCurrencyAmount,
+} from '../../../src/XRP/generated/org/xrpl/rpc/v1/amount_pb'
+import {
+  Account,
+  Amount,
+  Destination,
+  Domain,
+  Sequence,
+  SigningPublicKey,
+  Authorize,
+  Unauthorize,
+  ClearFlag,
+  EmailHash,
+  MessageKey,
+  SetFlag,
+  TransferRate,
+  TickSize,
+} from '../../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
+import {
+  Payment,
+  Transaction,
+  DepositPreauth,
+  AccountSet,
+} from '../../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
+
+
+const xrpTestUtils = {
+
+  /* eslint-disable no-shadow, max-params --
+  * The values we are shadowing are only used as inputs for this function,
+  * and it's fine to have a ton of parameters because this function is only used for testing purposes.
+  */
+  /**
+   * Create a new `Transaction` object with the given inputs.
+   *
+   * @param value - The amount of XRP to send, in drops.
+   * @param destinationAddress - The destination address.
+   * @param fee - The amount of XRP to use as a fee, in drops.
+   * @param lastLedgerSequenceNumber - The last ledger sequence the transaction will be valid in.
+   * @param sequenceNumber - The sequence number for the sending account.
+   * @param senderAddress - The address of the sending account.
+   * @param publicKey - The public key of the sending account, encoded as a hexadecimal string.
+   *
+   * @returns A new `Transaction` object comprised of the provided Transaction properties.
+   */
+  makePaymentTransaction(
+    value: string,
+    destinationAddress: string,
+    fee: string,
+    lastLedgerSequenceNumber: number,
+    sequenceNumber: number,
+    senderAddress: string | undefined,
+    publicKey: string,
+  ): Transaction {
+    const paymentAmount = new XRPDropsAmount()
+    paymentAmount.setDrops(value)
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(paymentAmount)
+
+    const amount = new Amount()
+    amount.setValue(currencyAmount)
+
+    const destinationAccountAddress = new AccountAddress()
+    destinationAccountAddress.setAddress(destinationAddress)
+
+    const destination = new Destination()
+    destination.setValue(destinationAccountAddress)
+
+    const payment = new Payment()
+    payment.setDestination(destination)
+    payment.setAmount(amount)
+
+    const transaction = this.makeBaseTransaction(
+      fee,
+      lastLedgerSequenceNumber,
+      sequenceNumber,
+      senderAddress,
+      publicKey,
+    )
+    transaction.setPayment(payment)
+
+    return transaction
+  },
+
+  /**
+   * Create a new `DepositPreauth` object with the given inputs.
+   *
+   * Note: Either the `authorizeAddress` or `unauthorizeAddress`, but not both, must be set to get a
+   * valid output. This precondition is not enforced by the function.
+   *
+   * @param authorizeAddress - The address to authorize.
+   * @param unauthorizeAddress - The address to unauthorize.
+   * @param fee - The amount of XRP to use as a fee, in drops.
+   * @param lastLedgerSequenceNumber - The last ledger sequence the transaction will be valid in.
+   * @param sequenceNumber - The sequence number for the sending account.
+   * @param senderAddress - The address of the sending account.
+   * @param publicKey - The public key of the sending account, encoded as a hexadecimal string.
+   *
+   * @returns A new `Transaction` object comprised of the provided properties.
+   */
+  makeDepositPreauth(
+    authorizeAddress: string | undefined,
+    unauthorizeAddress: string | undefined,
+    fee: string,
+    lastLedgerSequenceNumber: number,
+    sequenceNumber: number,
+    senderAddress: string | undefined,
+    publicKey: string,
+  ): Transaction {
+    const depositPreauth = new DepositPreauth()
+    if (authorizeAddress) {
+      const accountAddress = new AccountAddress()
+      accountAddress.setAddress(authorizeAddress)
+
+      const authorize = new Authorize()
+      authorize.setValue(accountAddress)
+
+      depositPreauth.setAuthorize(authorize)
+    } else if (unauthorizeAddress) {
+      const accountAddress = new AccountAddress()
+      accountAddress.setAddress(unauthorizeAddress)
+
+      const unauthorize = new Unauthorize()
+      unauthorize.setValue(accountAddress)
+
+      depositPreauth.setUnauthorize(unauthorize)
+    }
+
+    const transaction = this.makeBaseTransaction(
+      fee,
+      lastLedgerSequenceNumber,
+      sequenceNumber,
+      senderAddress,
+      publicKey,
+    )
+    transaction.setDepositPreauth(depositPreauth)
+
+    return transaction
+  },
+
+  /**
+   * Make a Transaction representing an AccountSet operation.
+   *
+   * @param clearFlagValue - The ClearFlag value to use for the AccountSet.
+   * @param domainValue - The Domain value to use for the AccountSet.
+   * @param emailHashValue - The EmailHash value to use for the AccountSet.
+   * @param messageKeyValue - The MesssageKey value to use for AccountSet.
+   * @param setFlagValue - The SetFlag value to use for the AccountSet.
+   * @param transferRateValue - The TransferRate value to use for the Accountset.
+   * @param tickSizeValue - The TickSize value to use for the AccountSet.
+   * @param fee - The amount of XRP to use as a fee, in drops.
+   * @param lastLedgerSequenceNumber - The last ledger sequence the transaction will be valid in.
+   * @param sequenceNumber - The sequence number for the sending account.
+   * @param senderAddress - The address of the sending account.
+   * @param publicKey - The public key of the sending account, encoded as a hexadecimal string.
+   * @returns A new `Transaction` object comprised of the provided properties.
+   */
+  makeAccountSetTransaction(
+    clearFlagValue: number | undefined,
+    domainValue: string | undefined,
+    emailHashValue: Uint8Array | undefined,
+    messageKeyValue: Uint8Array | undefined,
+    setFlagValue: number | undefined,
+    transferRateValue: number | undefined,
+    tickSizeValue: number | undefined,
+    fee: string,
+    lastLedgerSequenceNumber: number,
+    sequenceNumber: number,
+    senderAddress: string | undefined,
+    publicKey: string,
+  ): Transaction {
+    const accountSet = this.makeAccountSet(
+      clearFlagValue,
+      domainValue,
+      emailHashValue,
+      messageKeyValue,
+      setFlagValue,
+      transferRateValue,
+      tickSizeValue,
+    )
+    const transaction = this.makeBaseTransaction(
+      fee,
+      lastLedgerSequenceNumber,
+      sequenceNumber,
+      senderAddress,
+      publicKey,
+    )
+    transaction.setAccountSet(accountSet)
+
+    return transaction
+  },
+
+  /**
+   * Make an AccountSet protocol buffer from the given inputs.
+   *
+   * @param clearFlagValue - The ClearFlag value to use for the AccountSet.
+   * @param domainValue - The Domain value to use for the AccountSet.
+   * @param emailHashValue - The EmailHash value to use for the AccountSet.
+   * @param messageKeyValue - The MesssageKey value to use for AccountSet.
+   * @param setFlagValue - The SetFlag value to use for the AccountSet.
+   * @param transferRateValue - The TransferRate value to use for the Accountset.
+   * @param tickSizeValue - The TickSize value to use for the AccountSet.
+   * @returns An AccountSet protocol buffer from the given inputs.
+   */
+  makeAccountSet(
+    clearFlagValue: number | undefined,
+    domainValue: string | undefined,
+    emailHashValue: Uint8Array | undefined,
+    messageKeyValue: Uint8Array | undefined,
+    setFlagValue: number | undefined,
+    transferRateValue: number | undefined,
+    tickSizeValue: number | undefined,
+  ): AccountSet {
+    const accountSet = new AccountSet()
+    accountSet.setClearFlag()
+
+    if (clearFlagValue !== undefined) {
+      const clearFlag = new ClearFlag()
+      clearFlag.setValue(clearFlagValue)
+      accountSet.setClearFlag(clearFlag)
+    }
+
+    if (domainValue !== undefined) {
+      const domain = new Domain()
+      domain.setValue(domainValue)
+      accountSet.setDomain(domain)
+    }
+
+    if (emailHashValue !== undefined) {
+      const emailHash = new EmailHash()
+      emailHash.setValue(emailHashValue)
+      accountSet.setEmailHash(emailHash)
+    }
+
+    if (messageKeyValue !== undefined) {
+      const messageKey = new MessageKey()
+      messageKey.setValue(messageKeyValue)
+      accountSet.setMessageKey(messageKey)
+    }
+
+    if (setFlagValue !== undefined) {
+      const setFlag = new SetFlag()
+      setFlag.setValue(setFlagValue)
+      accountSet.setSetFlag(setFlag)
+    }
+
+    if (transferRateValue !== undefined) {
+      const transferRate = new TransferRate()
+      transferRate.setValue(transferRateValue)
+      accountSet.setTransferRate(transferRate)
+    }
+
+    if (tickSizeValue !== undefined) {
+      const tickSize = new TickSize()
+      tickSize.setValue(tickSizeValue)
+      accountSet.setTickSize(tickSize)
+    }
+
+    return accountSet
+  },
+
+  /**
+   * Make a transaction protocol buffer containing all the common fields.
+   *
+   * @param fee - The amount of XRP to use as a fee, in drops.
+   * @param lastLedgerSequenceNumber - The last ledger sequence the transaction will be valid in.
+   * @param sequenceNumber - The sequence number for the sending account.
+   * @param senderAddress - The address of the sending account.
+   * @param publicKey - The public key of the sending account, encoded as a hexadecimal string.
+   *
+   * @returns A transaction with common fields set.
+   */
+  makeBaseTransaction(
+    fee: string,
+    lastLedgerSequenceNumber: number,
+    sequenceNumber: number,
+    senderAddress: string | undefined,
+    publicKey: string,
+  ): Transaction {
+    const transactionFee = new XRPDropsAmount()
+    transactionFee.setDrops(fee)
+
+    const sequence = new Sequence()
+    sequence.setValue(sequenceNumber)
+
+    const lastLedgerSequence = new Sequence()
+    lastLedgerSequence.setValue(lastLedgerSequenceNumber)
+
+    const signingPublicKey = new SigningPublicKey()
+    signingPublicKey.setValue(Utils.toBytes(publicKey))
+
+    const transaction = new Transaction()
+    transaction.setFee(transactionFee)
+    transaction.setSequence(sequence)
+    transaction.setSigningPublicKey(signingPublicKey)
+    transaction.setLastLedgerSequence(lastLedgerSequence)
+
+    // Account is an optional input so that malformed transaction serialization can be tested.
+    if (senderAddress) {
+      const senderAccountAddress = new AccountAddress()
+      senderAccountAddress.setAddress(senderAddress)
+
+      const senderAccount = new Account()
+      senderAccount.setValue(senderAccountAddress)
+
+      transaction.setAccount(senderAccount)
+    }
+
+    return transaction
+  },
+  /* eslint-enable no-shadow, max-params */
+
+  /**
+   * Make a PathElement.
+   *
+   * Note: A valid path element should have either an account OR a currency and issuer but never both.
+   *
+   * @param account - The account to ripple through. Must not be provided if currency and issuer are provided.
+   * @param currencyCode - The currency code of the new currency on the path. Must not be provided if account is provided.
+   * @param issuer - The issuer of the new currency. Must not be provided if account is provided.
+   * @returns A PathElement with the given properties.
+   */
+  makePathElement(
+    account: AccountAddress | undefined,
+    currencyCode: Uint8Array | undefined,
+    issuer: AccountAddress | undefined,
+  ) {
+    const pathElement = new Payment.PathElement()
+
+    if (account !== undefined) {
+      pathElement.setAccount(account)
+    }
+
+    if (currencyCode !== undefined) {
+      const currency = new Currency()
+      currency.setCode(currencyCode)
+      pathElement.setCurrency(currency)
+    }
+
+    if (issuer !== undefined) {
+      pathElement.setIssuer(issuer)
+    }
+
+    return pathElement
+  },
+
+  /**
+   * Make an XRPDropsAmount.
+   *
+   * @param drops - A numeric string representing the number of drops.
+   * @returns A new XRPDropsAmount.
+   */
+  makeXrpDropsAmount(drops: string) {
+    const xrpDropsAmount = new XRPDropsAmount()
+    xrpDropsAmount.setDrops(drops)
+
+    return xrpDropsAmount
+  },
+
+  /**
+   * Make an IssuedCurrencyAmount.
+   *
+   * @param accountAddress - The account address.
+   * @param issuedCurrencyValue - The value.
+   * @param currency - The currency.
+   * @returns A new IssuedCurrencyAmount.
+   */
+  makeIssuedCurrencyAmount(
+    accountAddress: AccountAddress,
+    issuedCurrencyValue: string,
+    currency: Currency,
+  ) {
+    const issuedCurrency = new IssuedCurrencyAmount()
+    issuedCurrency.setIssuer(accountAddress)
+    issuedCurrency.setValue(issuedCurrencyValue)
+    issuedCurrency.setCurrency(currency)
+
+    return issuedCurrency
+  },
+
+  /**
+   * Returns a CurrencyAmount representing drops of XRP.
+   *
+   * @param drops - The number of drops to represent.
+   * @returns A CurrencyAmount representing the input.
+   */
+  makeXrpCurrencyAmount(drops: string): CurrencyAmount {
+    const xrpDropsAmount = this.makeXrpDropsAmount(drops)
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(xrpDropsAmount)
+
+    return currencyAmount
+  },
+
+  /**
+   * Returns a new account address.
+   *
+   * @param address - The address to wrap.
+   * @returns The requested object.
+   */
+  makeAccountAddress(address: string): AccountAddress {
+    const accountAddress = new AccountAddress()
+    accountAddress.setAddress(address)
+
+    return accountAddress
+  },
+}
+
+export default xrpTestUtils

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2718,7 +2718,7 @@ describe('serializer', function (): void {
   it('Serializes a list of signer entries', function (): void {
     // GIVEN a list of signer entries.
     const account1 = new Account()
-    account1.setValue(makeAccountAddress('r1'))
+    account1.setValue(xrpTestUtils.makeAccountAddress('r1'))
 
     const signerWeight1 = new SignerWeight()
     signerWeight1.setValue(1)
@@ -2728,7 +2728,7 @@ describe('serializer', function (): void {
     signerEntry1.setSignerWeight(signerWeight1)
 
     const account2 = new Account()
-    account2.setValue(makeAccountAddress('r2'))
+    account2.setValue(xrpTestUtils.makeAccountAddress('r2'))
 
     const signerWeight2 = new SignerWeight()
     signerWeight2.setValue(2)
@@ -2753,7 +2753,7 @@ describe('serializer', function (): void {
   it('Fails to serialize a list of signer entries where an entry is malformed', function (): void {
     // GIVEN a list of signer entries with a malformed second entry..
     const account1 = new Account()
-    account1.setValue(makeAccountAddress('r1'))
+    account1.setValue(xrpTestUtils.makeAccountAddress('r1'))
 
     const signerWeight1 = new SignerWeight()
     signerWeight1.setValue(1)

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2598,7 +2598,7 @@ describe('serializer', function (): void {
 
   it('Serializes a TrustSet with required fields', function (): void {
     // GIVEN a TrustSet with required fields.
-    const currencyAmount = makeXrpCurrencyAmount('10')
+    const currencyAmount = xrpTestUtils.makeXrpCurrencyAmount('10')
 
     const limitAmount = new LimitAmount()
     limitAmount.setValue(currencyAmount)
@@ -2620,7 +2620,7 @@ describe('serializer', function (): void {
 
   it('Serializes a TrustSet with all fields', function (): void {
     // GIVEN a TrustSet with all fields.
-    const currencyAmount = makeXrpCurrencyAmount('10')
+    const currencyAmount = xrpTestUtils.makeXrpCurrencyAmount('10')
 
     const limitAmount = new LimitAmount()
     limitAmount.setValue(currencyAmount)
@@ -2915,7 +2915,7 @@ describe('serializer', function (): void {
     signerQuorum.setValue(1)
 
     const account1 = new Account()
-    account1.setValue(makeAccountAddress('r1'))
+    account1.setValue(xrpTestUtils.makeAccountAddress('r1'))
 
     const signerWeight1 = new SignerWeight()
     signerWeight1.setValue(1)
@@ -2925,7 +2925,7 @@ describe('serializer', function (): void {
     signerEntry1.setSignerWeight(signerWeight1)
 
     const account2 = new Account()
-    account2.setValue(makeAccountAddress('r2'))
+    account2.setValue(xrpTestUtils.makeAccountAddress('r2'))
 
     const signerWeight2 = new SignerWeight()
     signerWeight2.setValue(2)

--- a/test/XRP/signer.test.ts
+++ b/test/XRP/signer.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements -- Allow many statements per test function. */
 /* eslint-disable import/max-dependencies -- Protocol buffer construction is verbose */
 import { assert } from 'chai'
 import * as rippleCodec from 'ripple-binary-codec'
@@ -14,6 +15,10 @@ import {
   Sequence,
   Account,
   Amount,
+  DestinationTag,
+  InvoiceID,
+  DeliverMin,
+  SendMax,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Payment,
@@ -24,10 +29,11 @@ import Signer from '../../src/XRP/signer'
 import XrpUtils from '../../src/XRP/xrp-utils'
 
 import FakeWallet from './fakes/fake-wallet'
+import xrpTestUtils from './helpers/xrp-test-utils'
 
-describe('signer', function (): void {
-  it('sign', function (): void {
-    // GIVEN an transaction and a wallet and expected signing artifacts.
+describe('Signer', function (): void {
+  it('Sign Payment transaction with mandatory fields', function (): void {
+    // GIVEN a Payment transaction, a wallet and expected signing artifacts.
     const fakeSignature = 'DEADBEEF'
     const wallet = new FakeWallet(fakeSignature)
 
@@ -95,8 +101,124 @@ describe('signer', function (): void {
     assert.deepEqual(signedTransaction, expectedSignedTransaction)
   })
 
+  it('Sign Payment transaction with all fields', function (): void {
+    // GIVEN a Payment transaction, a wallet and expected signing artifacts.
+    const fakeSignature = 'DEADBEEF'
+    const wallet = new FakeWallet(fakeSignature)
+
+    const value = '1000'
+    const destinationAddress = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
+    const fee = '10'
+    const sequenceNumber = 1
+    const account = 'X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4'
+    const destinationTagValue = 4
+    // invoiceId value should be either a base64 string or a 32-byte array representing 64 hex chars (256 bits)
+    const invoiceIdValue = 'ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0='
+    const deliverMinValue = '10'
+    const sendMaxValue = '13'
+
+    const paymentAmount = new XRPDropsAmount()
+    paymentAmount.setDrops(value)
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setXrpAmount(paymentAmount)
+
+    const destinationAccountAddress = new AccountAddress()
+    destinationAccountAddress.setAddress(destinationAddress)
+
+    const destination = new Destination()
+    destination.setValue(destinationAccountAddress)
+
+    const amount = new Amount()
+    amount.setValue(currencyAmount)
+
+    const destinationTag = new DestinationTag()
+    destinationTag.setValue(destinationTagValue)
+
+    const invoiceId = new InvoiceID()
+    invoiceId.setValue(invoiceIdValue)
+
+    const deliverMin = new DeliverMin()
+    deliverMin.setValue(xrpTestUtils.makeXrpCurrencyAmount(deliverMinValue))
+
+    const sendMax = new SendMax()
+    sendMax.setValue(xrpTestUtils.makeXrpCurrencyAmount(sendMaxValue))
+
+    const path1Element1 = xrpTestUtils.makePathElement(
+      xrpTestUtils.makeAccountAddress('rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'),
+      new Uint8Array([1, 2, 3, 4, 5]),
+      xrpTestUtils.makeAccountAddress('r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'),
+    )
+    const path1Element2 = xrpTestUtils.makePathElement(
+      xrpTestUtils.makeAccountAddress('rBM3QGATGQHRCBU8KtAvNvSHZrbJhMhWxA'),
+      new Uint8Array([4, 5, 6, 7, 8]),
+      xrpTestUtils.makeAccountAddress('r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'),
+    )
+
+    const path1 = new Payment.Path()
+    path1.addElements(path1Element1)
+    path1.addElements(path1Element2)
+
+    const path2Element1 = xrpTestUtils.makePathElement(
+      xrpTestUtils.makeAccountAddress('rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'),
+      new Uint8Array([7, 8, 9, 10, 11]),
+      xrpTestUtils.makeAccountAddress('rBM3QGATGQHRCBU8KtAvNvSHZrbJhMhWxA'),
+    )
+
+    const path2 = new Payment.Path()
+    path2.addElements(path2Element1)
+
+    const pathList = [path1, path2]
+    const payment = new Payment()
+    payment.setDestination(destination)
+    payment.setAmount(amount)
+    payment.setDestinationTag(destinationTag)
+    payment.setInvoiceId(invoiceId)
+    payment.setDeliverMin(deliverMin)
+    payment.setSendMax(sendMax)
+    payment.setPathsList(pathList)
+
+    const transactionFee = new XRPDropsAmount()
+    transactionFee.setDrops(fee)
+
+    const senderAccountAddress = new AccountAddress()
+    senderAccountAddress.setAddress(account)
+
+    const sender = new Account()
+    sender.setValue(senderAccountAddress)
+
+    const sequence = new Sequence()
+    sequence.setValue(sequenceNumber)
+
+    const transaction = new Transaction()
+    transaction.setAccount(sender)
+    transaction.setFee(transactionFee)
+    transaction.setSequence(sequence)
+    transaction.setPayment(payment)
+
+    // Encode transaction with the expected signature.
+    const expectedSignedTransactionJSON = Serializer.transactionToJSON(
+      transaction,
+      fakeSignature,
+    )
+
+    const expectedSignedTransactionHex = rippleCodec.encode(
+      expectedSignedTransactionJSON,
+    )
+    const expectedSignedTransaction = Utils.toBytes(
+      expectedSignedTransactionHex,
+    )
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransaction(transaction, wallet)
+
+    // THEN the signing artifacts are as expected.
+    assert.exists(signedTransaction)
+    assert.deepEqual(signedTransaction, expectedSignedTransaction)
+  })
+
   it('sign from JSON', function (): void {
-    // GIVEN an transaction and a wallet and expected signing artifacts.
+    // GIVEN a transaction, a wallet and expected signing artifacts.
     const fakeSignature = 'DEADBEEF'
     const wallet = new FakeWallet(fakeSignature)
     const destinationAddress = XrpUtils.decodeXAddress(


### PR DESCRIPTION
## High Level Overview of Change
This PR refactors the test utility functions into a separate helper file for re-use, and then uses these helpers in the process of a new `signer` test to test the signing of a `Payment` transaction with ALL fields set (now that the serializer supports serialization of all fields).

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
With the new version of `xpring-common-js` the SDKs tests were suddenly failing signing.  This `signer` test illuminates that some of the newly serialized `Payment` fields encounter strict format enforcements in the `ripple-binary-codec`.  Therefore, our integration tests in the SDKs need to use test values that conform to these realistic format requirements.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Refactor (non-breaking change that only restructures code)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After
Helper utilities refactored for better organization and re-usability.
New test for `signer` sanity-checks signing of the newly expanded `Payment` JSON.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
New test.  CI passes. 
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
Update the values used in integration tests in the SDKs to be in realistic, valid formats for consumption by the ripple binary codec.