### PR TITLE
Refactor Memo List Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -436,7 +436,10 @@ const serializer = {
       object.TxnSignature = signature
     }
 
-    Object.assign(object, this.memosToJSON(transaction.getMemosList()))
+    const memoList = transaction.getMemosList()
+    if (memoList.length > 0) {
+      object.Memos = this.memoListToJSON(memoList)
+    }
 
     const additionalTransactionData = getAdditionalTransactionData(transaction)
     if (additionalTransactionData === undefined) {
@@ -805,13 +808,9 @@ const serializer = {
    *
    * @returns An array of the Memos in JSON format, or undefined.
    */
-  memosToJSON(memos: Memo[]): { Memos: MemoJSON[] } | undefined {
-    if (!memos.length) {
-      return undefined
-    }
-
-    const convertedMemos = memos.map((memo) => this.memoToJSON(memo))
-    return { Memos: convertedMemos }
+  memoListToJSON(memos: Memo[]): MemoJSON[] {
+    // eslint-disable-next-line @typescript-eslint/unbound-method -- Manually assigning `this`.
+    return memos.map(this.memoToJSON, this)
   },
 
   /**

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -341,10 +341,6 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized, expectedJSON)
   })
 
-  it('serializes empty or blank memo arrays or objects to undefined', function (): void {
-    assert.isUndefined(Serializer.memosToJSON([]))
-  })
-
   it('serializes both memos with empty fields and complete fields correctly', function (): void {
     const memo = new Memo()
     const memoData = new MemoData()


### PR DESCRIPTION
## High Level Overview of Change

Refactor memo list to be standardized. 

### Context of Change

Refactor method to use same idioms as other list serialization methods (see for example, `pathListToJSON`). 

Specifically:
- Change name to `memoListToJSON` for consistency
- Use a simple map function internally
- Do not check inputs for validity, defer that responsibility to callers (note, this removes a unit test)
- Input is `Array<Memo>` and output is `Array<MemoJSON`>

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After

No change. This is prep work for a larger refactor of common transaction fields in #519 


## Test Plan

CI shows that this does not affect the public API; removed a unit test which was testing removed functionality. 