### PR TITLE
Bump `ripple-binary-codec` version to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6025,9 +6025,9 @@
       }
     },
     "ripple-binary-codec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.0.0.tgz",
-      "integrity": "sha512-sYpp/o4t8PQVvr7ubLeL5DXtgHOCG65wZuR2XFYtXc1bV1V03/yUDvNOAeXPfNSdIQ+Ydbj9aYIiPMsXKtq0Sg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.0.1.tgz",
+      "integrity": "sha512-y6pMZbCuBrd89fHabo16TTOdoL9XmSxZyKADJhBrvVFtTfN7ILC+139peWmvxWwEgnp9PKcZtn8RTuAIWYkQYg==",
       "requires": {
         "create-hash": "^1.2.0",
         "decimal.js": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "google-protobuf": "3.13.0",
     "grpc-web": "1.2.1",
     "ripple-address-codec": "4.1.1",
-    "ripple-binary-codec": "^1.0.0-rc3",
+    "ripple-binary-codec": "1.0.1",
     "ripple-keypairs": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## High Level Overview of Change
v1.0.1 of the `ripple-binary-code` contains a change that allows serialized JSON objects to contain `undefined` values, and then strips them out before signing, instead of throwing an error when encountering `undefined` values as in v1.0.0-rc3.  I want to make this explicit bump, and then cut a new release of `xpring-common-js` for incorporation into the SDKs.

`package-lock.json` is actually already up to date thanks to dependabot, hence the change to just `package.json`.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan

<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
