### PR TITLE
[6.2.2] Cut Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### [6.2.2] - 2020-09-11
+
+This minor release contains the newest version of the ripple-binary-codec (v1.0.1).
+
 ### [6.2.1] - 2020-09-02
 
 This release contains updated versions of dependencies for security and stability.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpring-common-js",
-  "version": "6.2.1",
+  "version": "6.2.2",
   "description": "Common JavaScript for use within the Xpring Platform",
   "repository": "https://github.com/xpring-eng/xpring-common-js.git",
   "license": "MIT",


### PR DESCRIPTION
## High Level Overview of Change

Cut release 6.2.2.  This out-of-band release bumps to the newest version of the `ripple-binary-codec`, which updates a design choice from codec `v1.0.0-rc3` that prevented integration of `xpring-common-js` v6.2.1 into the SDK.  I want to create this release ASAP in order to verify that the SDKs (especially Xpring4J and XpringKit - which can't be tested locally with x-c-js) accept this stack before heading into the normal release cycle on the 15th.

After merging this PR I will run:
```
$ git checkout master && git pull
$ git tag 'v6.2.2' && git push --tags
$ npm publish
```
### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->
- [x] Release
