### PR TITLE
Adds AccountSet Transaction Tests for `Signer`

### DIFF
--- a/test/XRP/fakes/fake-xrp-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-protobufs.ts
@@ -1,0 +1,141 @@
+import { AccountAddress } from '../../../src/XRP/generated/org/xrpl/rpc/v1/account_pb'
+import {
+  CurrencyAmount,
+  XRPDropsAmount,
+} from '../../../src/XRP/generated/org/xrpl/rpc/v1/amount_pb'
+import {
+  Destination,
+  Sequence,
+  Account,
+  Amount,
+  DestinationTag,
+  InvoiceID,
+  DeliverMin,
+  SendMax,
+} from '../../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
+import {
+  Payment,
+  Transaction,
+} from '../../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
+import xrpTestUtils from '../helpers/xrp-test-utils'
+
+// Constants
+const fakeSignature = 'DEADBEEF'
+const value = '1000'
+const destinationAddress = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
+const fee = '10'
+const sequenceNumber = 1
+const account = 'X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4'
+// invoiceId value should be either a base64 string or a 32-byte array representing 64 hex chars (256 bits)
+const invoiceIdValue = 'ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0='
+const deliverMinValue = '10'
+const sendMaxValue = '13'
+
+// Objects for Transactions
+
+const paymentAmount = new XRPDropsAmount()
+paymentAmount.setDrops(value)
+
+const currencyAmount = new CurrencyAmount()
+currencyAmount.setXrpAmount(paymentAmount)
+
+const destinationAccountAddress = new AccountAddress()
+destinationAccountAddress.setAddress(destinationAddress)
+
+const destination = new Destination()
+destination.setValue(destinationAccountAddress)
+
+const amount = new Amount()
+amount.setValue(currencyAmount)
+
+const transactionFee = new XRPDropsAmount()
+transactionFee.setDrops(fee)
+
+const senderAccountAddress = new AccountAddress()
+senderAccountAddress.setAddress(account)
+
+const sender = new Account()
+sender.setValue(senderAccountAddress)
+
+const sequence = new Sequence()
+sequence.setValue(sequenceNumber)
+
+const destinationTagValue = 4
+
+const destinationTag = new DestinationTag()
+destinationTag.setValue(destinationTagValue)
+
+const invoiceId = new InvoiceID()
+invoiceId.setValue(invoiceIdValue)
+
+const deliverMin = new DeliverMin()
+deliverMin.setValue(xrpTestUtils.makeXrpCurrencyAmount(deliverMinValue))
+
+const sendMax = new SendMax()
+sendMax.setValue(xrpTestUtils.makeXrpCurrencyAmount(sendMaxValue))
+
+// PathElements and Paths
+
+const path1Element1 = xrpTestUtils.makePathElement(
+  xrpTestUtils.makeAccountAddress('rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'),
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
+  new Uint8Array([1, 2, 3, 4, 5]),
+  xrpTestUtils.makeAccountAddress('r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'),
+)
+const path1Element2 = xrpTestUtils.makePathElement(
+  xrpTestUtils.makeAccountAddress('rBM3QGATGQHRCBU8KtAvNvSHZrbJhMhWxA'),
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
+  new Uint8Array([4, 5, 6, 7, 8]),
+  xrpTestUtils.makeAccountAddress('r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'),
+)
+
+const path1 = new Payment.Path()
+path1.addElements(path1Element1)
+path1.addElements(path1Element2)
+
+const path2Element1 = xrpTestUtils.makePathElement(
+  xrpTestUtils.makeAccountAddress('rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'),
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
+  new Uint8Array([7, 8, 9, 10, 11]),
+  xrpTestUtils.makeAccountAddress('rBM3QGATGQHRCBU8KtAvNvSHZrbJhMhWxA'),
+)
+
+const path2 = new Payment.Path()
+path2.addElements(path2Element1)
+
+const pathList = [path1, path2]
+
+// Payments
+
+const paymentMandatoryFields = new Payment()
+paymentMandatoryFields.setDestination(destination)
+paymentMandatoryFields.setAmount(amount)
+
+const paymentAllFields = new Payment()
+paymentAllFields.setDestination(destination)
+paymentAllFields.setAmount(amount)
+paymentAllFields.setDestinationTag(destinationTag)
+paymentAllFields.setInvoiceId(invoiceId)
+paymentAllFields.setDeliverMin(deliverMin)
+paymentAllFields.setSendMax(sendMax)
+paymentAllFields.setPathsList(pathList)
+
+// Transactions
+
+const testPaymentTransactionMandatoryFields = new Transaction()
+testPaymentTransactionMandatoryFields.setAccount(sender)
+testPaymentTransactionMandatoryFields.setFee(transactionFee)
+testPaymentTransactionMandatoryFields.setSequence(sequence)
+testPaymentTransactionMandatoryFields.setPayment(paymentMandatoryFields)
+
+const testPaymentTransactionAllFields = new Transaction()
+testPaymentTransactionAllFields.setAccount(sender)
+testPaymentTransactionAllFields.setFee(transactionFee)
+testPaymentTransactionAllFields.setSequence(sequence)
+testPaymentTransactionAllFields.setPayment(paymentAllFields)
+
+export {
+  fakeSignature,
+  testPaymentTransactionMandatoryFields,
+  testPaymentTransactionAllFields,
+}

--- a/test/XRP/fakes/fake-xrp-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-protobufs.ts
@@ -26,7 +26,6 @@ import xrpTestUtils from '../helpers/xrp-test-utils'
 const fakeSignature = 'DEADBEEF'
 const value = '1000'
 const currencyName = 'BTC'
-// const currencyCode = 'USD'
 const issuedCurrencyValue = '100'
 const destinationAddress = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
 const issuerAddress = 'rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY'
@@ -41,10 +40,8 @@ const sendMaxValue = '13'
 const destinationTagValue = 4
 
 // Objects for Transactions
-const testCurrencyProto = new Currency()
-// testCurrencyProto.setCode(currencyCode)
-testCurrencyProto.setName(currencyName)
 
+// AccountAddress
 const destinationAccountAddress = new AccountAddress()
 destinationAccountAddress.setAddress(destinationAddress)
 
@@ -54,6 +51,28 @@ issuerAccountAddress.setAddress(issuerAddress)
 const invalidAccountAddress = new AccountAddress()
 invalidAccountAddress.setAddress(invalidAddress)
 
+const senderAccountAddress = new AccountAddress()
+senderAccountAddress.setAddress(account)
+
+// Account
+const accountProto = new Account()
+accountProto.setValue(senderAccountAddress)
+
+// Destination
+const destination = new Destination()
+destination.setValue(destinationAccountAddress)
+
+const invalidDestination = new Destination()
+invalidDestination.setValue(invalidAccountAddress)
+
+// DestinationTag
+const destinationTag = new DestinationTag()
+destinationTag.setValue(destinationTagValue)
+
+// Currency/XRP/IssuedCurrency
+const testCurrencyProto = new Currency()
+testCurrencyProto.setName(currencyName)
+
 const paymentAmount = new XRPDropsAmount()
 paymentAmount.setDrops(value)
 
@@ -62,50 +81,41 @@ issuedCurrencyAmount.setCurrency(testCurrencyProto)
 issuedCurrencyAmount.setIssuer(issuerAccountAddress)
 issuedCurrencyAmount.setValue(issuedCurrencyValue)
 
+// CurrencyAmount
 const currencyAmountXrp = new CurrencyAmount()
 currencyAmountXrp.setXrpAmount(paymentAmount)
 
 const currencyAmountIssuedCurrency = new CurrencyAmount()
 currencyAmountIssuedCurrency.setIssuedCurrencyAmount(issuedCurrencyAmount)
 
-const destination = new Destination()
-destination.setValue(destinationAccountAddress)
-
-const invalidDestination = new Destination()
-invalidDestination.setValue(invalidAccountAddress)
-
+// Amount
 const amountXrp = new Amount()
 amountXrp.setValue(currencyAmountXrp)
 
 const amountIssuedCurrency = new Amount()
 amountIssuedCurrency.setValue(currencyAmountIssuedCurrency)
 
+// Transaction Fee
 const transactionFeeProto = new XRPDropsAmount()
 transactionFeeProto.setDrops(fee)
 
-const senderAccountAddress = new AccountAddress()
-senderAccountAddress.setAddress(account)
-
-const accountProto = new Account()
-accountProto.setValue(senderAccountAddress)
-
+// Sequence
 const sequenceProto = new Sequence()
 sequenceProto.setValue(sequenceNumber)
 
-const destinationTag = new DestinationTag()
-destinationTag.setValue(destinationTagValue)
-
+// InvoiceID
 const invoiceId = new InvoiceID()
 invoiceId.setValue(invoiceIdValue)
 
+// DeliverMin
 const deliverMin = new DeliverMin()
 deliverMin.setValue(xrpTestUtils.makeXrpCurrencyAmount(deliverMinValue))
 
+// SendMax
 const sendMax = new SendMax()
 sendMax.setValue(xrpTestUtils.makeXrpCurrencyAmount(sendMaxValue))
 
 // PathElements and Paths
-
 const path1Element1 = xrpTestUtils.makePathElement(
   xrpTestUtils.makeAccountAddress('rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'),
   // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
@@ -136,7 +146,6 @@ path2.addElements(path2Element1)
 const pathList = [path1, path2]
 
 // Payments
-
 const paymentMandatoryFields = new Payment()
 paymentMandatoryFields.setDestination(destination)
 paymentMandatoryFields.setAmount(amountXrp)

--- a/test/XRP/fakes/fake-xrp-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-protobufs.ts
@@ -85,7 +85,9 @@ const emailHashValue = generateValidUint8Array(HASH_LENGTH)
 const messageKeyValue = generateValidUint8Array(3)
 const setFlagValue = 4
 const transferRateValue = 1234567890
+const transferRateValueNoFee = 0
 const tickSizeValue = 7
+const tickSizeValueDisable = 0
 
 // Objects for Transactions
 
@@ -143,25 +145,37 @@ amountXrp.setValue(currencyAmountXrp)
 const amountIssuedCurrency = new Amount()
 amountIssuedCurrency.setValue(currencyAmountIssuedCurrency)
 
-// Transaction Fee
-const transactionFeeProto = new XRPDropsAmount()
-transactionFeeProto.setDrops(fee)
-
-// Sequence
-const sequenceProto = new Sequence()
-sequenceProto.setValue(sequenceNumber)
-
-// InvoiceID
-const invoiceId = new InvoiceID()
-invoiceId.setValue(invoiceIdValue)
+// ClearFlag
+const clearFlag = new ClearFlag()
+clearFlag.setValue(clearFlagValue)
 
 // DeliverMin
 const deliverMin = new DeliverMin()
 deliverMin.setValue(xrpTestUtils.makeXrpCurrencyAmount(deliverMinValue))
 
+// Domain
+const domain = new Domain()
+domain.setValue(domainValue)
+
+// EmailHash
+const emailHash = new EmailHash()
+emailHash.setValue(emailHashValue)
+
+// InvoiceID
+const invoiceId = new InvoiceID()
+invoiceId.setValue(invoiceIdValue)
+
 // SendMax
 const sendMax = new SendMax()
 sendMax.setValue(xrpTestUtils.makeXrpCurrencyAmount(sendMaxValue))
+
+// Sequence
+const sequenceProto = new Sequence()
+sequenceProto.setValue(sequenceNumber)
+
+// Transaction Fee
+const transactionFeeProto = new XRPDropsAmount()
+transactionFeeProto.setDrops(fee)
 
 // LastLedgerSequence
 const lastLedgerSequence = new LastLedgerSequence()
@@ -174,9 +188,31 @@ memoData.setValue(testMemoData)
 const memo = new Memo()
 memo.setMemoData(memoData)
 
+// MessageKey
+const messageKey = new MessageKey()
+messageKey.setValue(messageKeyValue)
+
+// SetFlag
+const setFlag = new SetFlag()
+setFlag.setValue(setFlagValue)
+
 // SourceTag
 const sourceTag = new SourceTag()
 sourceTag.setValue(sourceTagValue)
+
+// TransferRate
+const transferRate = new TransferRate()
+transferRate.setValue(transferRateValue)
+
+const transferRateNoFee = new TransferRate()
+transferRateNoFee.setValue(transferRateValueNoFee)
+
+// TickSize
+const tickSize = new TickSize()
+tickSize.setValue(tickSizeValue)
+
+const tickSizeDisable = new TickSize()
+tickSizeDisable.setValue(tickSizeValueDisable)
 
 // PathElements and Paths
 const path1Element1 = xrpTestUtils.makePathElement(
@@ -206,26 +242,6 @@ path2.addElements(path2Element1)
 const pathList = [path1, path2]
 
 // AccountSets
-const clearFlag = new ClearFlag()
-clearFlag.setValue(clearFlagValue)
-
-const domain = new Domain()
-domain.setValue(domainValue)
-
-const emailHash = new EmailHash()
-emailHash.setValue(emailHashValue)
-
-const messageKey = new MessageKey()
-messageKey.setValue(messageKeyValue)
-
-const setFlag = new SetFlag()
-setFlag.setValue(setFlagValue)
-
-const transferRate = new TransferRate()
-transferRate.setValue(transferRateValue)
-
-const tickSize = new TickSize()
-tickSize.setValue(tickSizeValue)
 
 const accountSetAllFields = new AccountSet()
 accountSetAllFields.setClearFlag(clearFlag)
@@ -240,6 +256,10 @@ const accountSetOneFieldSet = new AccountSet()
 accountSetOneFieldSet.setClearFlag(clearFlag)
 
 const accountSetEmpty = new AccountSet()
+
+const accountSetSpecialCases = new AccountSet()
+accountSetSpecialCases.setTransferRate(transferRateNoFee)
+accountSetSpecialCases.setTickSize(tickSizeDisable)
 
 // Payments
 const paymentMandatoryFields = new Payment()
@@ -291,14 +311,16 @@ const testTransactionAccountSetAllFields = buildStandardTestTransaction(
   accountSetAllFields,
   undefined,
 )
-
 const testTransactionAccountSetOneField = buildStandardTestTransaction(
   accountSetOneFieldSet,
   undefined,
 )
-
 const testTransactionAccountSetEmpty = buildStandardTestTransaction(
   accountSetEmpty,
+  undefined,
+)
+const testTransactionAccountSetSpecialCases = buildStandardTestTransaction(
+  accountSetSpecialCases,
   undefined,
 )
 
@@ -379,4 +401,5 @@ export {
   testTransactionAccountSetAllFields,
   testTransactionAccountSetOneField,
   testTransactionAccountSetEmpty,
+  testTransactionAccountSetSpecialCases,
 }

--- a/test/XRP/fakes/fake-xrp-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-protobufs.ts
@@ -40,12 +40,16 @@ import xrpTestUtils from '../helpers/xrp-test-utils'
  * Helper function for generating sample data.
  *
  * @param arrayLength - The desired array length.
+ * @param startValue - The first value in the array.
  *
  * @returns A UInt8Array with random data with the given length.
  */
-function generateValidUint8Array(arrayLength: number): Uint8Array {
+function generateValidUint8Array(
+  arrayLength: number,
+  startValue = 0,
+): Uint8Array {
   const numbers = new Array(arrayLength)
-  for (let index = 0; index < arrayLength; index++) {
+  for (let index = startValue; index < arrayLength; index++) {
     numbers[index] = index + 1
   }
   return new Uint8Array(numbers)
@@ -56,9 +60,9 @@ const fakeSignature = 'DEADBEEF'
 const value = '1000'
 const currencyName = 'BTC'
 // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
-const currencyCode1 = new Uint8Array([1, 2, 3, 4, 5])
+const currencyCode1 = generateValidUint8Array(5)
 // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
-const currencyCode2 = new Uint8Array([4, 5, 6, 7, 8])
+const currencyCode2 = generateValidUint8Array(5, 4)
 const issuedCurrencyValue = '100'
 const destinationAddress = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
 const issuerAddress = 'rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY'
@@ -75,13 +79,14 @@ const deliverMinValue = '10'
 const sendMaxValue = '13'
 const destinationTagValue = 4
 // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
-const testMemoData = new Uint8Array([2, 4, 6])
+const testMemoData = generateValidUint8Array(3, 10)
 const sourceTagValue = 5
 const lastLedgerSequenceValue = 78652515
 const clearFlagValue = 5
 const domainValue = 'testdomain'
 const HASH_LENGTH = 16
 const emailHashValue = generateValidUint8Array(HASH_LENGTH)
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
 const messageKeyValue = generateValidUint8Array(3)
 const setFlagValue = 4
 const transferRateValue = 1234567890

--- a/test/XRP/fakes/fake-xrp-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-protobufs.ts
@@ -219,6 +219,21 @@ const testInvalidTransactionPaymentBadDestination = buildStandardTransactionFrom
   testInvalidPaymentBadDestination,
 )
 
+const testInvalidTransactionPaymentNoAccount = new Transaction()
+testInvalidTransactionPaymentNoAccount.setFee(transactionFeeProto)
+testInvalidTransactionPaymentNoAccount.setSequence(sequenceProto)
+testInvalidTransactionPaymentNoAccount.setPayment(paymentMandatoryFields)
+
+const testInvalidTransactionPaymentNoFee = new Transaction()
+testInvalidTransactionPaymentNoFee.setAccount(accountProto)
+testInvalidTransactionPaymentNoFee.setSequence(sequenceProto)
+testInvalidTransactionPaymentNoFee.setPayment(paymentMandatoryFields)
+
+const testInvalidTransactionPaymentNoPayment = new Transaction()
+testInvalidTransactionPaymentNoPayment.setAccount(accountProto)
+testInvalidTransactionPaymentNoPayment.setFee(transactionFeeProto)
+testInvalidTransactionPaymentNoPayment.setSequence(sequenceProto)
+
 export {
   fakeSignature,
   testTransactionPaymentMandatoryFields,
@@ -227,4 +242,7 @@ export {
   testInvalidTransactionPaymentNoAmount,
   testInvalidTransactionPaymentNoDestination,
   testInvalidTransactionPaymentBadDestination,
+  testInvalidTransactionPaymentNoAccount,
+  testInvalidTransactionPaymentNoFee,
+  testInvalidTransactionPaymentNoPayment,
 }

--- a/test/XRP/fakes/fake-xrp-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-protobufs.ts
@@ -15,10 +15,14 @@ import {
   InvoiceID,
   DeliverMin,
   SendMax,
+  MemoData,
+  LastLedgerSequence,
+  SourceTag,
 } from '../../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Payment,
   Transaction,
+  Memo,
 } from '../../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import xrpTestUtils from '../helpers/xrp-test-utils'
 
@@ -26,9 +30,16 @@ import xrpTestUtils from '../helpers/xrp-test-utils'
 const fakeSignature = 'DEADBEEF'
 const value = '1000'
 const currencyName = 'BTC'
+const currencyCode1 = new Uint8Array([1, 2, 3, 4, 5])
+const currencyCode2 = new Uint8Array([4, 5, 6, 7, 8])
 const issuedCurrencyValue = '100'
 const destinationAddress = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
 const issuerAddress = 'rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY'
+const address1 = 'rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'
+const address2 = 'r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'
+const address3 = 'rBM3QGATGQHRCBU8KtAvNvSHZrbJhMhWxA'
+const address4 = 'r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'
+const address5 = 'rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'
 const invalidAddress = 'badAddress'
 const fee = '10'
 const sequenceNumber = 1
@@ -38,6 +49,9 @@ const invoiceIdValue = 'ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0='
 const deliverMinValue = '10'
 const sendMaxValue = '13'
 const destinationTagValue = 4
+const testMemoData = new Uint8Array([2, 4, 6])
+const sourceTagValue = 5
+const lastLedgerSequenceValue = 78652515
 
 // Objects for Transactions
 
@@ -115,18 +129,31 @@ deliverMin.setValue(xrpTestUtils.makeXrpCurrencyAmount(deliverMinValue))
 const sendMax = new SendMax()
 sendMax.setValue(xrpTestUtils.makeXrpCurrencyAmount(sendMaxValue))
 
+// LastLedgerSequence
+const lastLedgerSequence = new LastLedgerSequence()
+lastLedgerSequence.setValue(lastLedgerSequenceValue)
+
+// Memo
+const memoData = new MemoData()
+memoData.setValue(testMemoData)
+
+const memo = new Memo()
+memo.setMemoData(memoData)
+
+// SourceTag
+const sourceTag = new SourceTag()
+sourceTag.setValue(sourceTagValue)
+
 // PathElements and Paths
 const path1Element1 = xrpTestUtils.makePathElement(
-  xrpTestUtils.makeAccountAddress('rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'),
-  // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
-  new Uint8Array([1, 2, 3, 4, 5]),
-  xrpTestUtils.makeAccountAddress('r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'),
+  xrpTestUtils.makeAccountAddress(address1),
+  currencyCode1,
+  xrpTestUtils.makeAccountAddress(address2),
 )
 const path1Element2 = xrpTestUtils.makePathElement(
-  xrpTestUtils.makeAccountAddress('rBM3QGATGQHRCBU8KtAvNvSHZrbJhMhWxA'),
-  // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
-  new Uint8Array([4, 5, 6, 7, 8]),
-  xrpTestUtils.makeAccountAddress('r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'),
+  xrpTestUtils.makeAccountAddress(address3),
+  currencyCode2,
+  xrpTestUtils.makeAccountAddress(address4),
 )
 
 const path1 = new Payment.Path()
@@ -134,10 +161,9 @@ path1.addElements(path1Element1)
 path1.addElements(path1Element2)
 
 const path2Element1 = xrpTestUtils.makePathElement(
-  xrpTestUtils.makeAccountAddress('rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'),
-  // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
-  new Uint8Array([7, 8, 9, 10, 11]),
-  xrpTestUtils.makeAccountAddress('rBM3QGATGQHRCBU8KtAvNvSHZrbJhMhWxA'),
+  xrpTestUtils.makeAccountAddress(address5),
+  currencyCode1,
+  xrpTestUtils.makeAccountAddress(address3),
 )
 
 const path2 = new Payment.Path()
@@ -190,6 +216,9 @@ const testTransactionPaymentMandatoryFieldsIssuedCurrency = buildStandardTransac
 const testTransactionPaymentAllFields = buildStandardTransactionFromPayment(
   paymentAllFields,
 )
+testTransactionPaymentAllFields.addMemos(memo)
+testTransactionPaymentAllFields.setLastLedgerSequence(lastLedgerSequence)
+testTransactionPaymentAllFields.setSourceTag(sourceTag)
 
 // INVALID OBJECTS =============================================
 

--- a/test/XRP/fakes/fake-xrp-protobufs.ts
+++ b/test/XRP/fakes/fake-xrp-protobufs.ts
@@ -30,7 +30,9 @@ import xrpTestUtils from '../helpers/xrp-test-utils'
 const fakeSignature = 'DEADBEEF'
 const value = '1000'
 const currencyName = 'BTC'
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
 const currencyCode1 = new Uint8Array([1, 2, 3, 4, 5])
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
 const currencyCode2 = new Uint8Array([4, 5, 6, 7, 8])
 const issuedCurrencyValue = '100'
 const destinationAddress = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
@@ -38,8 +40,6 @@ const issuerAddress = 'rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY'
 const address1 = 'rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'
 const address2 = 'r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'
 const address3 = 'rBM3QGATGQHRCBU8KtAvNvSHZrbJhMhWxA'
-const address4 = 'r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'
-const address5 = 'rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'
 const invalidAddress = 'badAddress'
 const fee = '10'
 const sequenceNumber = 1
@@ -49,6 +49,7 @@ const invoiceIdValue = 'ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0='
 const deliverMinValue = '10'
 const sendMaxValue = '13'
 const destinationTagValue = 4
+// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
 const testMemoData = new Uint8Array([2, 4, 6])
 const sourceTagValue = 5
 const lastLedgerSequenceValue = 78652515
@@ -153,7 +154,7 @@ const path1Element1 = xrpTestUtils.makePathElement(
 const path1Element2 = xrpTestUtils.makePathElement(
   xrpTestUtils.makeAccountAddress(address3),
   currencyCode2,
-  xrpTestUtils.makeAccountAddress(address4),
+  xrpTestUtils.makeAccountAddress(address2),
 )
 
 const path1 = new Payment.Path()
@@ -161,7 +162,7 @@ path1.addElements(path1Element1)
 path1.addElements(path1Element2)
 
 const path2Element1 = xrpTestUtils.makePathElement(
-  xrpTestUtils.makeAccountAddress(address5),
+  xrpTestUtils.makeAccountAddress(address1),
   currencyCode1,
   xrpTestUtils.makeAccountAddress(address3),
 )

--- a/test/XRP/signer.test.ts
+++ b/test/XRP/signer.test.ts
@@ -12,6 +12,7 @@ import {
   fakeSignature,
   testTransactionAccountSetAllFields,
   testTransactionAccountSetOneField,
+  testTransactionAccountSetEmpty,
   testTransactionAccountSetSpecialCases,
   testTransactionPaymentMandatoryFields,
   testTransactionPaymentMandatoryFieldsIssuedCurrency,
@@ -295,7 +296,7 @@ describe('Signer', function (): void {
 
     // Encode transaction with the expected signature.
     const expectedSignedTransactionJSON = Serializer.transactionToJSON(
-      testTransactionAccountSetOneField,
+      testTransactionAccountSetEmpty,
       fakeSignature,
     )
 
@@ -308,7 +309,7 @@ describe('Signer', function (): void {
 
     // WHEN the transaction is signed with the wallet.
     const signedTransaction = Signer.signTransaction(
-      testTransactionAccountSetOneField,
+      testTransactionAccountSetEmpty,
       wallet,
     )
 

--- a/test/XRP/signer.test.ts
+++ b/test/XRP/signer.test.ts
@@ -21,6 +21,7 @@ import {
   testInvalidTransactionPaymentNoAccount,
   testInvalidTransactionPaymentNoFee,
   testInvalidTransactionPaymentNoPayment,
+  testTransactionAccountSetSpecialCases,
 } from './fakes/fake-xrp-protobufs'
 
 describe('Signer', function (): void {
@@ -308,6 +309,34 @@ describe('Signer', function (): void {
     // WHEN the transaction is signed with the wallet.
     const signedTransaction = Signer.signTransaction(
       testTransactionAccountSetOneField,
+      wallet,
+    )
+
+    // THEN the signing artifacts are as expected.
+    assert.exists(signedTransaction)
+    assert.deepEqual(signedTransaction, expectedSignedTransaction)
+  })
+
+  it('Sign AccountSet transaction with special case fields', function (): void {
+    // GIVEN a AccountSet transaction with fields set with special values, a wallet and expected signing artifacts.
+    const wallet = new FakeWallet(fakeSignature)
+
+    // Encode transaction with the expected signature.
+    const expectedSignedTransactionJSON = Serializer.transactionToJSON(
+      testTransactionAccountSetSpecialCases,
+      fakeSignature,
+    )
+
+    const expectedSignedTransactionHex = rippleCodec.encode(
+      expectedSignedTransactionJSON,
+    )
+    const expectedSignedTransaction = Utils.toBytes(
+      expectedSignedTransactionHex,
+    )
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransaction(
+      testTransactionAccountSetSpecialCases,
       wallet,
     )
 

--- a/test/XRP/signer.test.ts
+++ b/test/XRP/signer.test.ts
@@ -10,6 +10,8 @@ import XrpUtils from '../../src/XRP/xrp-utils'
 import FakeWallet from './fakes/fake-wallet'
 import {
   fakeSignature,
+  testTransactionAccountSetAllFields,
+  testTransactionAccountSetOneField,
   testTransactionPaymentMandatoryFields,
   testTransactionPaymentMandatoryFieldsIssuedCurrency,
   testTransactionPaymentAllFields,
@@ -22,6 +24,8 @@ import {
 } from './fakes/fake-xrp-protobufs'
 
 describe('Signer', function (): void {
+  // Payment Transactions
+
   it('Sign Payment transaction with mandatory fields', function (): void {
     // GIVEN a Payment transaction with mandatory fields, a wallet and expected signing artifacts.
     const wallet = new FakeWallet(fakeSignature)
@@ -182,7 +186,7 @@ describe('Signer', function (): void {
     }, Error)
   })
 
-  it('sign from JSON', function (): void {
+  it('Sign Payment transaction from JSON', function (): void {
     // GIVEN a transaction, a wallet and expected signing artifacts.
     const wallet = new FakeWallet(fakeSignature)
     const destinationAddress = XrpUtils.decodeXAddress(
@@ -219,6 +223,91 @@ describe('Signer', function (): void {
     // WHEN the transaction is signed with the wallet.
     const signedTransaction = Signer.signTransactionFromJSON(
       transactionJSON,
+      wallet,
+    )
+
+    // THEN the signing artifacts are as expected.
+    assert.exists(signedTransaction)
+    assert.deepEqual(signedTransaction, expectedSignedTransaction)
+  })
+  // AccountSet Transactions
+
+  it('Sign AccountSet transaction with all fields', function (): void {
+    // GIVEN a AccountSet transaction with all fields set, a wallet and expected signing artifacts.
+    const wallet = new FakeWallet(fakeSignature)
+
+    // Encode transaction with the expected signature.
+    const expectedSignedTransactionJSON = Serializer.transactionToJSON(
+      testTransactionAccountSetAllFields,
+      fakeSignature,
+    )
+
+    const expectedSignedTransactionHex = rippleCodec.encode(
+      expectedSignedTransactionJSON,
+    )
+    const expectedSignedTransaction = Utils.toBytes(
+      expectedSignedTransactionHex,
+    )
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransaction(
+      testTransactionAccountSetAllFields,
+      wallet,
+    )
+
+    // THEN the signing artifacts are as expected.
+    assert.exists(signedTransaction)
+    assert.deepEqual(signedTransaction, expectedSignedTransaction)
+  })
+
+  it('Sign AccountSet transaction with one field', function (): void {
+    // GIVEN a AccountSet transaction only one field set, a wallet and expected signing artifacts.
+    const wallet = new FakeWallet(fakeSignature)
+
+    // Encode transaction with the expected signature.
+    const expectedSignedTransactionJSON = Serializer.transactionToJSON(
+      testTransactionAccountSetOneField,
+      fakeSignature,
+    )
+
+    const expectedSignedTransactionHex = rippleCodec.encode(
+      expectedSignedTransactionJSON,
+    )
+    const expectedSignedTransaction = Utils.toBytes(
+      expectedSignedTransactionHex,
+    )
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransaction(
+      testTransactionAccountSetOneField,
+      wallet,
+    )
+
+    // THEN the signing artifacts are as expected.
+    assert.exists(signedTransaction)
+    assert.deepEqual(signedTransaction, expectedSignedTransaction)
+  })
+
+  it('Sign AccountSet transaction with no fields', function (): void {
+    // GIVEN a AccountSet transaction with no fields set, a wallet and expected signing artifacts.
+    const wallet = new FakeWallet(fakeSignature)
+
+    // Encode transaction with the expected signature.
+    const expectedSignedTransactionJSON = Serializer.transactionToJSON(
+      testTransactionAccountSetOneField,
+      fakeSignature,
+    )
+
+    const expectedSignedTransactionHex = rippleCodec.encode(
+      expectedSignedTransactionJSON,
+    )
+    const expectedSignedTransaction = Utils.toBytes(
+      expectedSignedTransactionHex,
+    )
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransaction(
+      testTransactionAccountSetOneField,
       wallet,
     )
 

--- a/test/XRP/signer.test.ts
+++ b/test/XRP/signer.test.ts
@@ -1,88 +1,26 @@
-/* eslint-disable max-statements -- Allow many statements per test function. */
-/* eslint-disable import/max-dependencies -- Protocol buffer construction is verbose */
 import { assert } from 'chai'
 import * as rippleCodec from 'ripple-binary-codec'
 
 import 'mocha'
 import Utils from '../../src/Common/utils'
-import { AccountAddress } from '../../src/XRP/generated/org/xrpl/rpc/v1/account_pb'
-import {
-  CurrencyAmount,
-  XRPDropsAmount,
-} from '../../src/XRP/generated/org/xrpl/rpc/v1/amount_pb'
-import {
-  Destination,
-  Sequence,
-  Account,
-  Amount,
-  DestinationTag,
-  InvoiceID,
-  DeliverMin,
-  SendMax,
-} from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
-import {
-  Payment,
-  Transaction,
-} from '../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 import Serializer, { TransactionJSON } from '../../src/XRP/serializer'
 import Signer from '../../src/XRP/signer'
 import XrpUtils from '../../src/XRP/xrp-utils'
 
 import FakeWallet from './fakes/fake-wallet'
-import xrpTestUtils from './helpers/xrp-test-utils'
+import {
+  fakeSignature,
+  testPaymentTransactionMandatoryFields,
+  testPaymentTransactionAllFields,
+} from './fakes/fake-xrp-protobufs'
 
 describe('Signer', function (): void {
   it('Sign Payment transaction with mandatory fields', function (): void {
     // GIVEN a Payment transaction, a wallet and expected signing artifacts.
-    const fakeSignature = 'DEADBEEF'
     const wallet = new FakeWallet(fakeSignature)
-
-    const value = '1000'
-    const destinationAddress = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
-    const fee = '10'
-    const sequenceNumber = 1
-    const account = 'X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4'
-
-    const paymentAmount = new XRPDropsAmount()
-    paymentAmount.setDrops(value)
-
-    const currencyAmount = new CurrencyAmount()
-    currencyAmount.setXrpAmount(paymentAmount)
-
-    const destinationAccountAddress = new AccountAddress()
-    destinationAccountAddress.setAddress(destinationAddress)
-
-    const destination = new Destination()
-    destination.setValue(destinationAccountAddress)
-
-    const amount = new Amount()
-    amount.setValue(currencyAmount)
-
-    const payment = new Payment()
-    payment.setDestination(destination)
-    payment.setAmount(amount)
-
-    const transactionFee = new XRPDropsAmount()
-    transactionFee.setDrops(fee)
-
-    const senderAccountAddress = new AccountAddress()
-    senderAccountAddress.setAddress(account)
-
-    const sender = new Account()
-    sender.setValue(senderAccountAddress)
-
-    const sequence = new Sequence()
-    sequence.setValue(sequenceNumber)
-
-    const transaction = new Transaction()
-    transaction.setAccount(sender)
-    transaction.setFee(transactionFee)
-    transaction.setSequence(sequence)
-    transaction.setPayment(payment)
-
     // Encode transaction with the expected signature.
     const expectedSignedTransactionJSON = Serializer.transactionToJSON(
-      transaction,
+      testPaymentTransactionMandatoryFields,
       fakeSignature,
     )
 
@@ -94,7 +32,10 @@ describe('Signer', function (): void {
     )
 
     // WHEN the transaction is signed with the wallet.
-    const signedTransaction = Signer.signTransaction(transaction, wallet)
+    const signedTransaction = Signer.signTransaction(
+      testPaymentTransactionMandatoryFields,
+      wallet,
+    )
 
     // THEN the signing artifacts are as expected.
     assert.exists(signedTransaction)
@@ -103,102 +44,11 @@ describe('Signer', function (): void {
 
   it('Sign Payment transaction with all fields', function (): void {
     // GIVEN a Payment transaction, a wallet and expected signing artifacts.
-    const fakeSignature = 'DEADBEEF'
     const wallet = new FakeWallet(fakeSignature)
-
-    const value = '1000'
-    const destinationAddress = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
-    const fee = '10'
-    const sequenceNumber = 1
-    const account = 'X7vjQVCddnQ7GCESYnYR3EdpzbcoAMbPw7s2xv8YQs94tv4'
-    const destinationTagValue = 4
-    // invoiceId value should be either a base64 string or a 32-byte array representing 64 hex chars (256 bits)
-    const invoiceIdValue = 'ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0='
-    const deliverMinValue = '10'
-    const sendMaxValue = '13'
-
-    const paymentAmount = new XRPDropsAmount()
-    paymentAmount.setDrops(value)
-
-    const currencyAmount = new CurrencyAmount()
-    currencyAmount.setXrpAmount(paymentAmount)
-
-    const destinationAccountAddress = new AccountAddress()
-    destinationAccountAddress.setAddress(destinationAddress)
-
-    const destination = new Destination()
-    destination.setValue(destinationAccountAddress)
-
-    const amount = new Amount()
-    amount.setValue(currencyAmount)
-
-    const destinationTag = new DestinationTag()
-    destinationTag.setValue(destinationTagValue)
-
-    const invoiceId = new InvoiceID()
-    invoiceId.setValue(invoiceIdValue)
-
-    const deliverMin = new DeliverMin()
-    deliverMin.setValue(xrpTestUtils.makeXrpCurrencyAmount(deliverMinValue))
-
-    const sendMax = new SendMax()
-    sendMax.setValue(xrpTestUtils.makeXrpCurrencyAmount(sendMaxValue))
-
-    const path1Element1 = xrpTestUtils.makePathElement(
-      xrpTestUtils.makeAccountAddress('rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'),
-      new Uint8Array([1, 2, 3, 4, 5]),
-      xrpTestUtils.makeAccountAddress('r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'),
-    )
-    const path1Element2 = xrpTestUtils.makePathElement(
-      xrpTestUtils.makeAccountAddress('rBM3QGATGQHRCBU8KtAvNvSHZrbJhMhWxA'),
-      new Uint8Array([4, 5, 6, 7, 8]),
-      xrpTestUtils.makeAccountAddress('r4L6ZLHkTytPqDR81H1ysCr6qGv9oJJAKi'),
-    )
-
-    const path1 = new Payment.Path()
-    path1.addElements(path1Element1)
-    path1.addElements(path1Element2)
-
-    const path2Element1 = xrpTestUtils.makePathElement(
-      xrpTestUtils.makeAccountAddress('rQ3fNyLjbvcDaPNS4EAJY8aT9zR3uGk17c'),
-      new Uint8Array([7, 8, 9, 10, 11]),
-      xrpTestUtils.makeAccountAddress('rBM3QGATGQHRCBU8KtAvNvSHZrbJhMhWxA'),
-    )
-
-    const path2 = new Payment.Path()
-    path2.addElements(path2Element1)
-
-    const pathList = [path1, path2]
-    const payment = new Payment()
-    payment.setDestination(destination)
-    payment.setAmount(amount)
-    payment.setDestinationTag(destinationTag)
-    payment.setInvoiceId(invoiceId)
-    payment.setDeliverMin(deliverMin)
-    payment.setSendMax(sendMax)
-    payment.setPathsList(pathList)
-
-    const transactionFee = new XRPDropsAmount()
-    transactionFee.setDrops(fee)
-
-    const senderAccountAddress = new AccountAddress()
-    senderAccountAddress.setAddress(account)
-
-    const sender = new Account()
-    sender.setValue(senderAccountAddress)
-
-    const sequence = new Sequence()
-    sequence.setValue(sequenceNumber)
-
-    const transaction = new Transaction()
-    transaction.setAccount(sender)
-    transaction.setFee(transactionFee)
-    transaction.setSequence(sequence)
-    transaction.setPayment(payment)
 
     // Encode transaction with the expected signature.
     const expectedSignedTransactionJSON = Serializer.transactionToJSON(
-      transaction,
+      testPaymentTransactionAllFields,
       fakeSignature,
     )
 
@@ -210,7 +60,10 @@ describe('Signer', function (): void {
     )
 
     // WHEN the transaction is signed with the wallet.
-    const signedTransaction = Signer.signTransaction(transaction, wallet)
+    const signedTransaction = Signer.signTransaction(
+      testPaymentTransactionAllFields,
+      wallet,
+    )
 
     // THEN the signing artifacts are as expected.
     assert.exists(signedTransaction)
@@ -219,7 +72,6 @@ describe('Signer', function (): void {
 
   it('sign from JSON', function (): void {
     // GIVEN a transaction, a wallet and expected signing artifacts.
-    const fakeSignature = 'DEADBEEF'
     const wallet = new FakeWallet(fakeSignature)
     const destinationAddress = XrpUtils.decodeXAddress(
       'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc',

--- a/test/XRP/signer.test.ts
+++ b/test/XRP/signer.test.ts
@@ -16,6 +16,9 @@ import {
   testInvalidTransactionPaymentNoAmount,
   testInvalidTransactionPaymentNoDestination,
   testInvalidTransactionPaymentBadDestination,
+  testInvalidTransactionPaymentNoAccount,
+  testInvalidTransactionPaymentNoFee,
+  testInvalidTransactionPaymentNoPayment,
 } from './fakes/fake-xrp-protobufs'
 
 describe('Signer', function (): void {
@@ -138,6 +141,44 @@ describe('Signer', function (): void {
         testInvalidTransactionPaymentBadDestination,
         wallet,
       )
+    }, Error)
+  })
+
+  it('Sign Payment transaction with no account', function (): void {
+    // GIVEN a Payment transaction without a account field and a wallet.
+    const wallet = new FakeWallet(fakeSignature)
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransaction(
+      testInvalidTransactionPaymentNoAccount,
+      wallet,
+    )
+
+    // THEN the signing artifacts are undefined.
+    assert.isUndefined(signedTransaction)
+  })
+
+  it('Sign Payment transaction with no fee', function (): void {
+    // GIVEN a Payment transaction without a transaction fee field and a wallet.
+    const wallet = new FakeWallet(fakeSignature)
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransaction(
+      testInvalidTransactionPaymentNoFee,
+      wallet,
+    )
+
+    // THEN the signing artifacts are undefined.
+    assert.isUndefined(signedTransaction)
+  })
+
+  it('Sign Payment transaction with no payment', function (): void {
+    // GIVEN a Payment transaction without a payment field and a wallet.
+    const wallet = new FakeWallet(fakeSignature)
+
+    // WHEN the transaction is signed with the wallet THEN an error is thrown.
+    assert.throws(() => {
+      Signer.signTransaction(testInvalidTransactionPaymentNoPayment, wallet)
     }, Error)
   })
 


### PR DESCRIPTION
## High Level Overview of Change

This PR adds additional testing for `Signer` for `AccountSet` transactions. 

### Context of Change

This is a part of an initiative to have better testing for `Signer`, to catch bugs quickly and more easily in the future. 

### Type of Change

- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

New tests added for `Signer`. 

## Test Plan

CI passes. 

## Future Tasks
More tests for `Signer` will be added. 
