### PR TITLE
Serializes TrustSet Transactions

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -251,6 +251,7 @@ type TransactionDataJSON =
   | PaymentChannelCreateJSON
   | PaymentChannelFundJSON
   | SetRegularKeyJSON
+  | TrustSetJSON
 
 /**
  * Individual Transaction Types.
@@ -275,6 +276,7 @@ type PaymentChannelCreateTransactionJSON = BaseTransactionJSON &
 type PaymentChannelFundTransactionJSON = BaseTransactionJSON &
   PaymentChannelFundJSON
 type SetRegularKeyTransactionJSON = BaseTransactionJSON & SetRegularKeyJSON
+type TrustSetTransactionJSON = BaseTransactionJSON & TrustSetJSON
 
 /**
  * All Transactions.
@@ -297,6 +299,7 @@ export type TransactionJSON =
   | PaymentChannelClaimTransactionJSON
   | PaymentChannelFundTransactionJSON
   | SetRegularKeyTransactionJSON
+  | TrustSetTransactionJSON
 
 /**
  * Types for serialized sub-objects.
@@ -1965,7 +1968,13 @@ function getAdditionalTransactionData(
 
       return serializer.paymentToJSON(payment)
     }
-
+    case Transaction.TransactionDataCase.TRUST_SET: {
+      const trustSet = transaction.getTrustSet()
+      if (trustSet === undefined) {
+        return undefined
+      }
+      return serializer.trustSetToJSON(trustSet)
+    }
     default:
       throw new Error('Unexpected transactionDataCase')
   }

--- a/test/XRP/helpers/xrp-test-utils.ts
+++ b/test/XRP/helpers/xrp-test-utils.ts
@@ -1,6 +1,6 @@
-/* eslint-disable max-params -- only for testing purposes */
-/* eslint-disable max-statements -- only for testing purposes */
-/* eslint-disable max-lines -- only for testing purposes */
+/* eslint-disable max-params -- Allow lots of sample data to be used. */
+/* eslint-disable max-statements -- Allow many lines per function. */
+/* eslint-disable max-lines -- Allow many lines of test util functions. */
 import Utils from '../../../src/Common/utils'
 import { AccountAddress } from '../../../src/XRP/generated/org/xrpl/rpc/v1/account_pb'
 import {

--- a/test/XRP/helpers/xrp-test-utils.ts
+++ b/test/XRP/helpers/xrp-test-utils.ts
@@ -294,7 +294,7 @@ const xrpTestUtils = {
     senderAddress: string | undefined,
     publicKey: string,
   ): Transaction {
-    const accountSet = this.makeTrustSet(
+    const trustSet = this.makeTrustSet(
       limitAmountCurrency,
       limitAmountIssuer,
       limitAmountValue,
@@ -308,7 +308,7 @@ const xrpTestUtils = {
       senderAddress,
       publicKey,
     )
-    transaction.setAccountSet(accountSet)
+    transaction.setTrustSet(trustSet)
 
     return transaction
   },

--- a/test/XRP/helpers/xrp-test-utils.ts
+++ b/test/XRP/helpers/xrp-test-utils.ts
@@ -1,3 +1,6 @@
+/* eslint-disable max-params -- only for testing purposes */
+/* eslint-disable max-statements -- only for testing purposes */
+/* eslint-disable max-lines -- only for testing purposes */
 import Utils from '../../../src/Common/utils'
 import { AccountAddress } from '../../../src/XRP/generated/org/xrpl/rpc/v1/account_pb'
 import {
@@ -21,12 +24,16 @@ import {
   SetFlag,
   TransferRate,
   TickSize,
+  LimitAmount,
+  QualityIn,
+  QualityOut,
 } from '../../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Payment,
   Transaction,
   DepositPreauth,
   AccountSet,
+  TrustSet,
 } from '../../../src/XRP/generated/org/xrpl/rpc/v1/transaction_pb'
 
 const xrpTestUtils = {
@@ -258,6 +265,105 @@ const xrpTestUtils = {
     }
 
     return accountSet
+  },
+
+  /**
+   * Make a Transaction representing a TrustSet operation.
+   *
+   * @param limitAmountCurrency - The currency name to use for the LimitAmount for the TrustSet.
+   * @param limitAmountIssuer - The issuer address to use for the LimitAmount for the TrustSet.
+   * @param limitAmountValue - The value to use for the LimitAmount for the TrustSet.
+   * @param qualityInValue - The QualityIn value to use for the LimitAmount for the TrustSet.
+   * @param qualityOutValue - The QualityOut value to use for the LimitAmount for the TrustSet.
+   * @param fee - The amount of XRP to use as a fee, in drops.
+   * @param lastLedgerSequenceNumber - The last ledger sequence the transaction will be valid in.
+   * @param sequenceNumber - The sequence number for the sending account.
+   * @param senderAddress - The address of the sending account.
+   * @param publicKey - The public key of the sending account, encoded as a hexadecimal string.
+   * @returns A new `Transaction` object comprised of the provided properties.
+   */
+  makeTrustSetTransaction(
+    limitAmountCurrency: string,
+    limitAmountIssuer: string,
+    limitAmountValue: string,
+    qualityInValue: number | undefined,
+    qualityOutValue: number | undefined,
+    fee: string,
+    lastLedgerSequenceNumber: number,
+    sequenceNumber: number,
+    senderAddress: string | undefined,
+    publicKey: string,
+  ): Transaction {
+    const accountSet = this.makeTrustSet(
+      limitAmountCurrency,
+      limitAmountIssuer,
+      limitAmountValue,
+      qualityInValue,
+      qualityOutValue,
+    )
+    const transaction = this.makeBaseTransaction(
+      fee,
+      lastLedgerSequenceNumber,
+      sequenceNumber,
+      senderAddress,
+      publicKey,
+    )
+    transaction.setAccountSet(accountSet)
+
+    return transaction
+  },
+
+  /**
+   * Make a TrustSet protocol buffer from the given inputs.
+   *
+   * @param limitAmountCurrency - The currency name to use for the LimitAmount for the TrustSet.
+   * @param limitAmountIssuer - The issuer address to use for the LimitAmount for the TrustSet.
+   * @param limitAmountValue - The value to use for the LimitAmount for the TrustSet.
+   * @param qualityInValue - The QualityIn value to use for the LimitAmount for the TrustSet.
+   * @param qualityOutValue - The QualityOut value to use for the LimitAmount for the TrustSet.
+   * @returns A TrustSet protocol buffer from the given inputs.
+   */
+  makeTrustSet(
+    limitAmountCurrency: string,
+    limitAmountIssuer: string,
+    limitAmountValue: string,
+    qualityInValue: number | undefined,
+    qualityOutValue: number | undefined,
+  ): TrustSet {
+    const trustSet = new TrustSet()
+
+    const currency = new Currency()
+    currency.setName(limitAmountCurrency)
+
+    const issuerAccountAddress = new AccountAddress()
+    issuerAccountAddress.setAddress(limitAmountIssuer)
+
+    const issuedCurrencyAmount = new IssuedCurrencyAmount()
+    issuedCurrencyAmount.setCurrency(currency)
+    issuedCurrencyAmount.setIssuer(issuerAccountAddress)
+    issuedCurrencyAmount.setValue(limitAmountValue)
+
+    const currencyAmount = new CurrencyAmount()
+    currencyAmount.setIssuedCurrencyAmount(issuedCurrencyAmount)
+
+    const limitAmount = new LimitAmount()
+    limitAmount.setValue(currencyAmount)
+
+    trustSet.setLimitAmount(limitAmount)
+
+    if (qualityInValue !== undefined) {
+      const qualityIn = new QualityIn()
+      qualityIn.setValue(qualityInValue)
+      trustSet.setQualityIn(qualityIn)
+    }
+
+    if (qualityOutValue !== undefined) {
+      const qualityOut = new QualityOut()
+      qualityOut.setValue(qualityOutValue)
+      trustSet.setQualityOut(qualityOut)
+    }
+
+    return trustSet
   },
 
   /**

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2674,11 +2674,12 @@ describe('serializer', function (): void {
   })
 
   it('serializes a TrustSet transaction', function (): void {
-    // GIVEN a transaction which represents a payment to a destination without a tag, denominated in XRP.
+    // GIVEN a transaction which represents the creation of a trust line linking two accounts.
     const currency = 'USD'
+    const currencyIssuer = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
     const transaction = xrpTestUtils.makeTrustSetTransaction(
       currency,
-      destinationXAddressWithoutTag,
+      currencyIssuer,
       value,
       undefined,
       undefined,
@@ -2699,7 +2700,7 @@ describe('serializer', function (): void {
       LastLedgerSequence: lastLedgerSequenceValue,
       LimitAmount: {
         currency,
-        issuer: destinationXAddressWithoutTag,
+        issuer: currencyIssuer,
         value,
       },
       Sequence: sequenceValue,

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2710,6 +2710,28 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized, expectedJSON)
   })
 
+  it('serializes a faulty TrustSet transaction', function (): void {
+    // GIVEN a bad transaction which represents the creation of a trust line linking two accounts.
+    const transaction = xrpTestUtils.makeTrustSetTransaction(
+      '',
+      '',
+      value,
+      undefined,
+      undefined,
+      fee,
+      lastLedgerSequenceValue,
+      sequenceValue,
+      accountClassicAddress,
+      publicKeyHex,
+    )
+
+    // WHEN the transaction is serialized to JSON.
+    const serialized = Serializer.transactionToJSON(transaction)
+
+    // THEN the result is undefined.
+    assert.isUndefined(serialized)
+  })
+
   it('Serializes a SignerEntry', function (): void {
     // GIVEN a SignerEntry
     const account = new Account()

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2673,6 +2673,42 @@ describe('serializer', function (): void {
     assert.isUndefined(serialized)
   })
 
+  it('serializes a TrustSet transaction', function (): void {
+    // GIVEN a transaction which represents a payment to a destination without a tag, denominated in XRP.
+    const currency = 'USD'
+    const transaction = xrpTestUtils.makeTrustSetTransaction(
+      currency,
+      destinationXAddressWithoutTag,
+      value,
+      undefined,
+      undefined,
+      fee,
+      lastLedgerSequenceValue,
+      sequenceValue,
+      accountClassicAddress,
+      publicKeyHex,
+    )
+
+    // WHEN the transaction is serialized to JSON.
+    const serialized = Serializer.transactionToJSON(transaction)
+
+    // THEN the result is as expected.
+    const expectedJSON: TransactionJSON = {
+      Account: accountClassicAddress,
+      Fee: fee.toString(),
+      LastLedgerSequence: lastLedgerSequenceValue,
+      LimitAmount: {
+        currency,
+        issuer: destinationXAddressWithoutTag,
+        value,
+      },
+      Sequence: sequenceValue,
+      TransactionType: 'TrustSet',
+      SigningPubKey: publicKeyHex,
+    }
+    assert.deepEqual(serialized, expectedJSON)
+  })
+
   it('Serializes a SignerEntry', function (): void {
     // GIVEN a SignerEntry
     const account = new Account()


### PR DESCRIPTION
## High Level Overview of Change

Provides serialization of TrustSet transaction protocol buffers. 

### Context of Change

`TrustSet` is one of the few transaction types in use at the moment. It was unable to be properly serialized. 

This was caught in the process of writing more `Signer` tests for transactions.

### Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After

`TrustSet` transactions can now be fully serialized. 

## Test Plan

CI passes. New unit test written. 