### PR TITLE
Serializes flags on transactions

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -92,6 +92,7 @@ interface BaseTransactionJSON {
   SigningPubKey: string
   TxnSignature?: string
   Memos?: MemoJSON[]
+  Flags?: FlagsJSON
 }
 
 /**
@@ -380,6 +381,7 @@ type SignerWeightJSON = number
 type QualityInJSON = number
 type QualityOutJSON = number
 type LimitAmountJSON = CurrencyAmountJSON
+type FlagsJSON = number
 
 /**
  * Provides functionality to serialize from protocol buffers to JSON objects.
@@ -442,6 +444,11 @@ const serializer = {
     const memoList = transaction.getMemosList()
     if (memoList.length > 0) {
       object.Memos = this.memoListToJSON(memoList)
+    }
+
+    const flags = transaction.getFlags()
+    if (flags) {
+      object.Flags = flags.getValue()
     }
 
     const additionalTransactionData = getAdditionalTransactionData(transaction)

--- a/test/XRP/fakes/fake-protobufs.ts
+++ b/test/XRP/fakes/fake-protobufs.ts
@@ -30,7 +30,6 @@ import {
   LimitAmount,
   QualityIn,
   QualityOut,
-  Flags,
 } from '../../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,

--- a/test/XRP/fakes/fake-protobufs.ts
+++ b/test/XRP/fakes/fake-protobufs.ts
@@ -422,16 +422,6 @@ const testTransactionTrustSetSpecialCases = buildStandardTestTransaction(
   trustSetSpecial,
 )
 
-const testTransactionTrustSetFlagSet = buildStandardTestTransaction(
-  Transaction.TransactionDataCase.TRUST_SET,
-  trustSetMandatoryFields,
-)
-
-const trustSetFlags = new Flags()
-trustSetFlags.setValue(65536)
-
-testTransactionTrustSetFlagSet.setFlags(trustSetFlags)
-
 // INVALID OBJECTS =============================================
 
 // Invalid Payments
@@ -501,7 +491,6 @@ export {
   testTransactionTrustSetMandatoryFields,
   testTransactionTrustSetAllFields,
   testTransactionTrustSetSpecialCases,
-  testTransactionTrustSetFlagSet,
   testInvalidTransactionPaymentNoAmount,
   testInvalidTransactionPaymentNoDestination,
   testInvalidTransactionPaymentBadDestination,

--- a/test/XRP/fakes/fake-protobufs.ts
+++ b/test/XRP/fakes/fake-protobufs.ts
@@ -30,6 +30,7 @@ import {
   LimitAmount,
   QualityIn,
   QualityOut,
+  Flags,
 } from '../../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   AccountSet,
@@ -421,6 +422,16 @@ const testTransactionTrustSetSpecialCases = buildStandardTestTransaction(
   trustSetSpecial,
 )
 
+const testTransactionTrustSetFlagSet = buildStandardTestTransaction(
+  Transaction.TransactionDataCase.TRUST_SET,
+  trustSetMandatoryFields,
+)
+
+const trustSetFlags = new Flags()
+trustSetFlags.setValue(65536)
+
+testTransactionTrustSetFlagSet.setFlags(trustSetFlags)
+
 // INVALID OBJECTS =============================================
 
 // Invalid Payments
@@ -490,6 +501,7 @@ export {
   testTransactionTrustSetMandatoryFields,
   testTransactionTrustSetAllFields,
   testTransactionTrustSetSpecialCases,
+  testTransactionTrustSetFlagSet,
   testInvalidTransactionPaymentNoAmount,
   testInvalidTransactionPaymentNoDestination,
   testInvalidTransactionPaymentBadDestination,

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2712,7 +2712,7 @@ describe('serializer', function (): void {
     assert.deepEqual(serialized, expectedJSON)
   })
 
-  it.only('serializes a TrustSet transaction with flags set', function (): void {
+  it('serializes a TrustSet transaction with flags set', function (): void {
     // GIVEN a transaction which represents the creation of a trust line linking two accounts.
     const currency = 'USD'
     const currencyIssuer = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
@@ -2728,6 +2728,9 @@ describe('serializer', function (): void {
       accountClassicAddress,
       publicKeyHex,
     )
+    const flags = new Flags()
+    flags.setValue(flagsValue)
+    transaction.setFlags(flags)
 
     // WHEN the transaction is serialized to JSON.
     const serialized = Serializer.transactionToJSON(transaction)

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -2713,7 +2713,7 @@ describe('serializer', function (): void {
   })
 
   it('serializes a TrustSet transaction with flags set', function (): void {
-    // GIVEN a transaction which represents the creation of a trust line linking two accounts.
+    // GIVEN a transaction which represents the creation of a trust line linking two accounts, with flags.
     const currency = 'USD'
     const currencyIssuer = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
     const transaction = xrpTestUtils.makeTrustSetTransaction(

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -63,6 +63,7 @@ import {
   QualityOut,
   LimitAmount,
   SignerEntry,
+  Flags,
 } from '../../src/XRP/generated/org/xrpl/rpc/v1/common_pb'
 import {
   Memo,
@@ -128,6 +129,7 @@ const dataForMemo = Utils.toBytes('I forgot to pick up Carl...')
 const typeForMemo = Utils.toBytes('meme')
 const formatForMemo = Utils.toBytes('jaypeg')
 const offerSequenceNumber = 1234
+const flagsValue = 65536
 
 const testAccountAddress = xrpTestUtils.makeAccountAddress(
   destinationClassicAddress,
@@ -2706,6 +2708,44 @@ describe('serializer', function (): void {
       Sequence: sequenceValue,
       TransactionType: 'TrustSet',
       SigningPubKey: publicKeyHex,
+    }
+    assert.deepEqual(serialized, expectedJSON)
+  })
+
+  it.only('serializes a TrustSet transaction with flags set', function (): void {
+    // GIVEN a transaction which represents the creation of a trust line linking two accounts.
+    const currency = 'USD'
+    const currencyIssuer = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
+    const transaction = xrpTestUtils.makeTrustSetTransaction(
+      currency,
+      currencyIssuer,
+      value,
+      undefined,
+      undefined,
+      fee,
+      lastLedgerSequenceValue,
+      sequenceValue,
+      accountClassicAddress,
+      publicKeyHex,
+    )
+
+    // WHEN the transaction is serialized to JSON.
+    const serialized = Serializer.transactionToJSON(transaction)
+
+    // THEN the result is as expected.
+    const expectedJSON: TransactionJSON = {
+      Account: accountClassicAddress,
+      Fee: fee.toString(),
+      LastLedgerSequence: lastLedgerSequenceValue,
+      LimitAmount: {
+        currency,
+        issuer: currencyIssuer,
+        value,
+      },
+      Sequence: sequenceValue,
+      TransactionType: 'TrustSet',
+      SigningPubKey: publicKeyHex,
+      Flags: flagsValue,
     }
     assert.deepEqual(serialized, expectedJSON)
   })

--- a/test/XRP/signer.test.ts
+++ b/test/XRP/signer.test.ts
@@ -22,6 +22,7 @@ import {
   testTransactionTrustSetMandatoryFields,
   testTransactionTrustSetAllFields,
   testTransactionTrustSetSpecialCases,
+  testTransactionTrustSetFlagSet,
   testInvalidTransactionPaymentNoAmount,
   testInvalidTransactionPaymentNoDestination,
   testInvalidTransactionPaymentBadDestination,
@@ -449,5 +450,33 @@ describe('Signer', function (): void {
 
     // THEN the signing artifacts are undefined.
     assert.isUndefined(signedTransaction)
+  })
+
+  it.only('Sign TrustSet transaction with flag set', function (): void {
+    // GIVEN a TrustSet transaction with mandatory fields, a wallet and expected signing artifacts.
+    const wallet = new FakeWallet(fakeSignature)
+
+    // Encode transaction with the expected signature.
+    const expectedSignedTransactionJSON = Serializer.transactionToJSON(
+      testTransactionTrustSetFlagSet,
+      fakeSignature,
+    )
+
+    const expectedSignedTransactionHex = rippleCodec.encode(
+      expectedSignedTransactionJSON,
+    )
+    const expectedSignedTransaction = Utils.toBytes(
+      expectedSignedTransactionHex,
+    )
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransaction(
+      testTransactionTrustSetFlagSet,
+      wallet,
+    )
+
+    // THEN the signing artifacts are as expected.
+    assert.exists(signedTransaction)
+    assert.deepEqual(signedTransaction, expectedSignedTransaction)
   })
 })

--- a/test/XRP/signer.test.ts
+++ b/test/XRP/signer.test.ts
@@ -22,7 +22,6 @@ import {
   testTransactionTrustSetMandatoryFields,
   testTransactionTrustSetAllFields,
   testTransactionTrustSetSpecialCases,
-  testTransactionTrustSetFlagSet,
   testInvalidTransactionPaymentNoAmount,
   testInvalidTransactionPaymentNoDestination,
   testInvalidTransactionPaymentBadDestination,
@@ -450,33 +449,5 @@ describe('Signer', function (): void {
 
     // THEN the signing artifacts are undefined.
     assert.isUndefined(signedTransaction)
-  })
-
-  it.only('Sign TrustSet transaction with flag set', function (): void {
-    // GIVEN a TrustSet transaction with mandatory fields, a wallet and expected signing artifacts.
-    const wallet = new FakeWallet(fakeSignature)
-
-    // Encode transaction with the expected signature.
-    const expectedSignedTransactionJSON = Serializer.transactionToJSON(
-      testTransactionTrustSetFlagSet,
-      fakeSignature,
-    )
-
-    const expectedSignedTransactionHex = rippleCodec.encode(
-      expectedSignedTransactionJSON,
-    )
-    const expectedSignedTransaction = Utils.toBytes(
-      expectedSignedTransactionHex,
-    )
-
-    // WHEN the transaction is signed with the wallet.
-    const signedTransaction = Signer.signTransaction(
-      testTransactionTrustSetFlagSet,
-      wallet,
-    )
-
-    // THEN the signing artifacts are as expected.
-    assert.exists(signedTransaction)
-    assert.deepEqual(signedTransaction, expectedSignedTransaction)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change
This PR serializes the optional `Flags` field on transactions, and adds a test.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
In order to authorize a Trust Line, we need to set a `Flag` on a `TrustSet` transaction. Unfortunately, we are not currently serializing this field.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
Flags are serialized instead of silently being ignored
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI, the test I added
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
