### PR TITLE
Fixes Missing `TransactionType` for `OfferCreateJSON` and Adds Signing Tests

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -213,6 +213,7 @@ export interface OfferCreateJSON {
   OfferSequence?: OfferSequenceJSON
   TakerGets: TakerGetsJSON
   TakerPays: TakerPaysJSON
+  TransactionType: 'OfferCreate'
 }
 
 export interface SignerListSetJSON {
@@ -1595,6 +1596,7 @@ const serializer = {
     const json: OfferCreateJSON = {
       TakerGets: takerGetsJSON,
       TakerPays: takerPaysJSON,
+      TransactionType: 'OfferCreate',
     }
 
     // Process optional fields.

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -1906,6 +1906,7 @@ describe('serializer', function (): void {
     const expected: OfferCreateJSON = {
       TakerGets: Serializer.takerGetsToJSON(takerGets)!,
       TakerPays: Serializer.takerPaysToJSON(takerPays)!,
+      TransactionType: 'OfferCreate',
     }
     assert.deepEqual(serialized, expected)
   })
@@ -1939,6 +1940,7 @@ describe('serializer', function (): void {
       TakerPays: Serializer.takerPaysToJSON(takerPays)!,
       Expiration: Serializer.expirationToJSON(expiration),
       OfferSequence: Serializer.offerSequenceToJSON(offerSequence),
+      TransactionType: 'OfferCreate',
     }
     assert.deepEqual(serialized, expected)
   })

--- a/test/XRP/signer.test.ts
+++ b/test/XRP/signer.test.ts
@@ -16,6 +16,8 @@ import {
   testTransactionAccountSetOneField,
   testTransactionAccountSetEmpty,
   testTransactionAccountSetSpecialCases,
+  testTransactionOfferCancelAllFields,
+  testTransactionOfferCreateAllFields,
   testTransactionPaymentMandatoryFields,
   testTransactionPaymentMandatoryFieldsIssuedCurrency,
   testTransactionPaymentAllFields,
@@ -449,5 +451,61 @@ describe('Signer', function (): void {
 
     // THEN the signing artifacts are undefined.
     assert.isUndefined(signedTransaction)
+  })
+
+  it('Sign OfferCancel transaction with all fields', function (): void {
+    // GIVEN an OfferCancel transaction with all fields, a wallet and expected signing artifacts.
+    const wallet = new FakeWallet(fakeSignature)
+
+    // Encode transaction with the expected signature.
+    const expectedSignedTransactionJSON = Serializer.transactionToJSON(
+      testTransactionOfferCancelAllFields,
+      fakeSignature,
+    )
+
+    const expectedSignedTransactionHex = rippleCodec.encode(
+      expectedSignedTransactionJSON,
+    )
+    const expectedSignedTransaction = Utils.toBytes(
+      expectedSignedTransactionHex,
+    )
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransaction(
+      testTransactionOfferCancelAllFields,
+      wallet,
+    )
+
+    // THEN the signing artifacts are as expected.
+    assert.exists(signedTransaction)
+    assert.deepEqual(signedTransaction, expectedSignedTransaction)
+  })
+
+  it('Sign OfferCreate transaction with all fields', function (): void {
+    // GIVEN an OfferCreate transaction with all fields, a wallet and expected signing artifacts.
+    const wallet = new FakeWallet(fakeSignature)
+
+    // Encode transaction with the expected signature.
+    const expectedSignedTransactionJSON = Serializer.transactionToJSON(
+      testTransactionOfferCreateAllFields,
+      fakeSignature,
+    )
+
+    const expectedSignedTransactionHex = rippleCodec.encode(
+      expectedSignedTransactionJSON,
+    )
+    const expectedSignedTransaction = Utils.toBytes(
+      expectedSignedTransactionHex,
+    )
+
+    // WHEN the transaction is signed with the wallet.
+    const signedTransaction = Signer.signTransaction(
+      testTransactionOfferCreateAllFields,
+      wallet,
+    )
+
+    // THEN the signing artifacts are as expected.
+    assert.exists(signedTransaction)
+    assert.deepEqual(signedTransaction, expectedSignedTransaction)
   })
 })


### PR DESCRIPTION
## High Level Overview of Change
This PR fixes a bug in which the serialization code for `OfferCreate` transaction protobufs wasn't assigning a transaction type string to the corresponding JSON.  It also adds tests for signing `OfferCreate` and `OfferCancel` transactions, since these are new types that we're about to be using the SDK.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
OfferCreate / OfferCancel need to be working.
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests (You added tests for code that already exists, or your new feature included in this PR)

## Before / After
`OfferCreate` can now be signed.  Tests for `OfferCreate` and `OfferCancel`.

<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
New tests added, CI passes
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->


## Future Tasks
<!--
For future tasks related to PR.
-->
We should be sure to add signing tests for any new transaction types that the SDK comes to require.
