### PR TITLE
Fixes A Bug In PathElement Serialization

### DIFF
--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -324,7 +324,7 @@ interface MemoDetailsJSON {
 interface PathElementJSON {
   account?: string
   issuer?: string
-  currencyCode?: CurrencyJSON
+  currency?: CurrencyJSON
 }
 
 interface IssuedCurrencyAmountJSON {
@@ -518,7 +518,7 @@ const serializer = {
         return this.pathToJSON(path)
       })
     }
-
+    
     return json
   },
 
@@ -799,7 +799,7 @@ const serializer = {
 
     const currency = pathElement.getCurrency()
     if (currency) {
-      json.currencyCode = this.currencyToJSON(currency)
+      json.currency = this.currencyToJSON(currency)
     }
 
     const account = pathElement.getAccount()?.getAddress()

--- a/src/XRP/serializer.ts
+++ b/src/XRP/serializer.ts
@@ -518,7 +518,7 @@ const serializer = {
         return this.pathToJSON(path)
       })
     }
-    
+
     return json
   },
 

--- a/test/XRP/fakes/fake-protobufs.ts
+++ b/test/XRP/fakes/fake-protobufs.ts
@@ -2,6 +2,7 @@
 /* eslint-disable max-statements -- long functions are fine here */
 /* eslint-disable max-lines -- lots of test data */
 /* eslint-disable max-len -- long variable names and function names */
+import Utils from '../../../src/Common/utils'
 import { AccountAddress } from '../../../src/XRP/generated/org/xrpl/rpc/v1/account_pb'
 import {
   CurrencyAmount,
@@ -71,10 +72,9 @@ function generateValidUint8Array(
 const fakeSignature = 'DEADBEEF'
 const value = '1000'
 const currencyName = 'BTC'
-// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
-const currencyCode1 = generateValidUint8Array(5)
-// eslint-disable-next-line @typescript-eslint/no-magic-numbers -- sample data
-const currencyCode2 = generateValidUint8Array(5, 4)
+// Valid hex code required by signer, pulled from https://xrpl.org/currency-formats.html#currency-codes
+const currencyCode1 = Utils.toBytes('0158415500000000C1F76FF6ECB0BAC600000000')
+const currencyCode2 = Utils.toBytes('0158415500000000C1F76FF6ECB0BAC600000000')
 const issuedCurrencyValue = '100'
 const destinationAddress = 'XVPcpSm47b1CZkf5AkKM9a84dQHe3m4sBhsrA4XtnBECTAc'
 const issuerAddress = 'rPEPPER7kfTD9w2To4CQk6UCfuHM9c6GDY'

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -576,7 +576,10 @@ describe('serializer', function (): void {
 
   it('serializes a PathElement with issued currency', function (): void {
     // GIVEN a PathElement with a currency code and an issuer.
-    const currencyCode = new Uint8Array([0, 1, 2, 3])
+    // Valid hex code required by signer, pulled from https://xrpl.org/currency-formats.html#currency-codes
+    const currencyCode = Utils.toBytes(
+      '0158415500000000C1F76FF6ECB0BAC600000000',
+    )
     const pathElement = xrpTestUtils.makePathElement(
       undefined,
       currencyCode,

--- a/test/XRP/serializer.test.ts
+++ b/test/XRP/serializer.test.ts
@@ -570,7 +570,7 @@ describe('serializer', function (): void {
     assert.equal(serialized.account, testAccountAddress.getAddress())
 
     // AND the currency and issuer fields are undefined.
-    assert.isUndefined(serialized.currencyCode)
+    assert.isUndefined(serialized.currency)
     assert.isUndefined(serialized.issuer)
   })
 
@@ -587,7 +587,7 @@ describe('serializer', function (): void {
     const serialized = Serializer.pathElementToJSON(pathElement)
 
     // THEN the currency and issuer fields are set.
-    assert.deepEqual(serialized.currencyCode, Utils.toHex(currencyCode))
+    assert.deepEqual(serialized.currency, Utils.toHex(currencyCode))
     assert.equal(serialized.issuer, testAccountAddress.getAddress())
 
     // AND the account is undefined.


### PR DESCRIPTION
## High Level Overview of Change
This PR fixes a bug in the serializer code that incorrectly assigned the field `currencyCode` to a path element instead of the `currency` field expected by the rippled server.  We have signer tests for these serialized objects that do cover paths, but this bug wasn't obviously detectable until attempting to send an actual transaction to the network.

<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [x] Bug fix (non-breaking change which fixes an issue)

## Before / After
Path elements correctly serialized.
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
Change tests to check for correct `currency` field.  npm link locally to test successful submission of transaction with paths.
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
