### PR TITLE
Removes use of payid-org/utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "webpack": "npm run clean && ./scripts/regenerate_protos.sh && npm run lint && tsc --noEmit && webpack && copyfiles -u 3 './src/XRP/generated/**/*' ./dist/XRP/generated"
   },
   "dependencies": {
-    "@payid-org/utils": "^1.2.0",
     "bip32": "2.0.6",
     "bip39": "^3.0.2",
     "google-protobuf": "3.13.0",

--- a/src/PayID/pay-id-utils.ts
+++ b/src/PayID/pay-id-utils.ts
@@ -1,5 +1,3 @@
-import * as utils from '@payid-org/utils'
-
 import PayIdComponents from './pay-id-components'
 
 /**
@@ -13,13 +11,38 @@ const payIdUtils = {
    * @returns A PayIdComponents object if the input was valid, otherwise undefined.
    */
   parsePayId(payId: string): PayIdComponents | undefined {
-    try {
-      utils.parsePayId(payId)
-      const [path, host] = utils.splitPayIdString(payId)
-      return new PayIdComponents(host, `/${path}`)
-    } catch {
+    if (!this.isASCII(payId)) {
       return undefined
     }
+
+    // Split on the last occurrence of '$'
+    const lastDollarIndex = payId.lastIndexOf('$')
+    if (lastDollarIndex === -1) {
+      return undefined
+    }
+    const path = payId.slice(0, lastDollarIndex)
+    const host = payId.slice(lastDollarIndex + 1)
+
+    // Validate the host and path have values.
+    if (host.length === 0 || path.length === 0) {
+      return undefined
+    }
+
+    return new PayIdComponents(host, `/${path}`)
+  },
+
+  /**
+   * Validate if the input is ASCII based text.
+   *
+   * Shamelessly taken from:
+   * https://stackoverflow.com/questions/14313183/javascript-regex-how-do-i-check-if-the-string-is-ascii-only.
+   *
+   * @param input - The input to check.
+   * @returns A boolean indicating the result.
+   */
+  isASCII(input: string): boolean {
+    // eslint-disable-next-line no-control-regex -- The ASCII regex uses control characters
+    return /^[\x00-\x7F]*$/u.test(input)
   },
 }
 export default payIdUtils

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,10 +21,6 @@ module.exports = {
   resolve: {
     extensions: ['.ts', '.js'],
   },
-  node: {
-    // @payid-org/utils has a dependency on fs
-    fs: 'empty',
-  },
   output: {
     filename: 'index.js',
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
## High Level Overview of Change
Reverts https://github.com/xpring-eng/xpring-common-js/pull/542. We don't need Verifiable PayID and it's causing some problems.
<!--
Please include a summary/list of the changes.
If too broad, please consider splitting into multiple PRs.
If a relevant Asana task, please link it here.
-->

### Context of Change
Needed for something else. `jose` is problematic and this is the fastest path to success. 
<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a design document for this feature, please link it here.
-->

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Before / After
xpring-common-js no longer uses payid-org/utils
<!--
If just refactoring / back-end changes, this can be just an in-English description of the change at a technical level.
If a UI change, screenshots should be included.
-->

## Test Plan
CI, tests
<!--
Please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
